### PR TITLE
feat: support building image from existing volume snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Optional backup storage settings let you export the resulting image when `backup
 
 Use `image_description` to set a custom description for the generated image.
 
+The plugin also supports building an image directly from an existing **volume snapshot** by setting `source_volume_snapshot_uuid`. In this mode no VM is created and SSH/provisioners are skipped — see [`example/from_snapshot.pkr.hcl`](example/from_snapshot.pkr.hcl).
+
 See the [`example/`](example) directory for ready-to-run HCL examples covering account/password auth, AK/SK auth, and UUID passthrough.
 
 ## E2E Test Method

--- a/builder/zstack/builder.go
+++ b/builder/zstack/builder.go
@@ -27,7 +27,11 @@ func (b *Builder) Prepare(raws ...any) ([]string, []string, error) {
 	errs := b.config.Prepare(raws...)
 
 	if b.config.Comm.Type == "" {
-		b.config.Comm.Type = "ssh"
+		if b.config.SourceVolumeSnapshotUuid != "" {
+			b.config.Comm.Type = "none"
+		} else {
+			b.config.Comm.Type = "ssh"
+		}
 	}
 
 	//var errs *packer.MultiError
@@ -55,6 +59,25 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	state.Put("driver", driver)
 	state.Put("config", &b.config)
 	state.Put("hook", hook)
+
+	var steps []multistep.Step
+
+	if b.config.SourceVolumeSnapshotUuid != "" {
+		log.Printf("[INFO] Using snapshot-only build path (source_volume_snapshot_uuid=%s)", b.config.SourceVolumeSnapshotUuid)
+		steps = []multistep.Step{
+			&StepPreValidate{},
+			&StepCreateImageFromSnapshot{},
+			&StepWaitForImageReady{},
+			&StepExportImage{},
+		}
+
+		log.Printf("[DEBUG] Build steps prepared with %s", b.config.RedactedSummary())
+
+		b.runner = commonsteps.NewRunner(steps, b.config.PackerConfig, ui)
+		b.runner.Run(ctx, state)
+
+		return b.collectArtifact(state, driver)
+	}
 
 	baseSteps := []multistep.Step{
 		&StepPreValidate{},
@@ -107,13 +130,17 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		&StepExportImage{},
 	)
 
-	steps := append(baseSteps, remainingSteps...)
+	steps = append(baseSteps, remainingSteps...)
 
 	log.Printf("[DEBUG] Build steps prepared with %s", b.config.RedactedSummary())
 
 	b.runner = commonsteps.NewRunner(steps, b.config.PackerConfig, ui)
 	b.runner.Run(ctx, state)
 
+	return b.collectArtifact(state, driver)
+}
+
+func (b *Builder) collectArtifact(state multistep.StateBag, driver Driver) (packersdk.Artifact, error) {
 	var urls []string
 	if v, ok := state.GetOk("image_url"); ok {
 		switch val := v.(type) {
@@ -134,7 +161,6 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		}
 	}
 
-	// Error Handler
 	if rawErr, ok := state.GetOk("error"); ok {
 		if err, ok := rawErr.(error); ok {
 			return nil, err

--- a/builder/zstack/builder.hcl2spec.go
+++ b/builder/zstack/builder.hcl2spec.go
@@ -23,7 +23,9 @@ type FlatConfig struct {
 	SourceImageUrl   *string `mapstructure:"source_image_url" cty:"source_image_url" hcl:"source_image_url"`
 	Format           *string `mapstructure:"format" cty:"format" hcl:"format"`
 	//BackupStorageUuids *[]string `mapstructure:"backup_storage_uuids" cty:"backup_storage_uuids" hcl:"backup_storage_uuids"`
-	Platform *string `mapstructure:"platform" cty:"platform" hcl:"platform"`
+	Platform                 *string `mapstructure:"platform" cty:"platform" hcl:"platform"`
+	Architecture             *string `mapstructure:"architecture" cty:"architecture" hcl:"architecture"`
+	SourceVolumeSnapshotUuid *string `mapstructure:"source_volume_snapshot_uuid" cty:"source_volume_snapshot_uuid" hcl:"source_volume_snapshot_uuid"`
 
 	L3NetworkUuid *string `mapstructure:"network_uuid" cty:"network_uuid" hcl:"network_uuid"`
 	L3NetworkName *string `mapstructure:"network_name" cty:"network_name" hcl:"network_name"`
@@ -82,7 +84,9 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"source_image_url":  &hcldec.AttrSpec{Name: "source_image_url", Type: cty.String, Required: false},
 		"format":            &hcldec.AttrSpec{Name: "format", Type: cty.String, Required: false},
 		//"backup_storage_uuids": &hcldec.AttrSpec{Name: "format", Type: cty.String, Required: false},
-		"platform": &hcldec.AttrSpec{Name: "platform", Type: cty.String, Required: false},
+		"platform":                    &hcldec.AttrSpec{Name: "platform", Type: cty.String, Required: false},
+		"architecture":                &hcldec.AttrSpec{Name: "architecture", Type: cty.String, Required: false},
+		"source_volume_snapshot_uuid": &hcldec.AttrSpec{Name: "source_volume_snapshot_uuid", Type: cty.String, Required: false},
 
 		"network_uuid": &hcldec.AttrSpec{Name: "network_uuid", Type: cty.String, Required: false},
 		"network_name": &hcldec.AttrSpec{Name: "network_name", Type: cty.String, Required: false},

--- a/builder/zstack/config.go
+++ b/builder/zstack/config.go
@@ -63,15 +63,17 @@ func (c *Config) VmRunningTimeout() time.Duration {
 }
 
 type ImageConfig struct {
-	ImageName          string   `mapstructure:"image_name"`
-	ImageDescription   string   `mapstructure:"image_description"`
-	SourceImage        string   `mapstructure:"source_image"`
-	GuestOsType        string   `mapstructure:"guest_os_type"`
-	SourceImageUrl     string   `mapstructure:"source_image_url"`
-	Format             string   `mapstructure:"format"`
-	BackupStorageUuids []string `mapstructure:"backup_storage_uuids"`
-	ImageUuid          string   `mapstructure:"image_uuid"`
-	Platform           string   `mapstructure:"platform"`
+	ImageName                string   `mapstructure:"image_name"`
+	ImageDescription         string   `mapstructure:"image_description"`
+	SourceImage              string   `mapstructure:"source_image"`
+	GuestOsType              string   `mapstructure:"guest_os_type"`
+	SourceImageUrl           string   `mapstructure:"source_image_url"`
+	Format                   string   `mapstructure:"format"`
+	BackupStorageUuids       []string `mapstructure:"backup_storage_uuids"`
+	ImageUuid                string   `mapstructure:"image_uuid"`
+	Platform                 string   `mapstructure:"platform"`
+	Architecture             string   `mapstructure:"architecture"`
+	SourceVolumeSnapshotUuid string   `mapstructure:"source_volume_snapshot_uuid"`
 }
 
 type NetworkConfig struct {
@@ -165,6 +167,20 @@ func (c *Config) Prepare(raws ...any) error {
 		}
 		if c.SourceImage == "" {
 			errs = packersdk.MultiErrorAppend(errs, errors.New("source image name must be specified when using source_image_url"))
+		}
+	}
+
+	if c.SourceVolumeSnapshotUuid != "" {
+		log.Printf("[INFO] Configuring image creation from volume snapshot: %s", c.SourceVolumeSnapshotUuid)
+		if c.ImageName == "" {
+			errs = packersdk.MultiErrorAppend(errs, errors.New("image_name must be specified when using source_volume_snapshot_uuid"))
+		}
+		if c.BackupStorageConfig.BackupStorageUuid == "" && c.BackupStorageConfig.BackupStorageName == "" {
+			errs = packersdk.MultiErrorAppend(errs, errors.New("backup_storage_name or backup_storage_uuid is required when using source_volume_snapshot_uuid"))
+		}
+		if c.Platform == "" {
+			c.Platform = "Linux"
+			log.Printf("[DEBUG] Default platform set to: %s", c.Platform)
 		}
 	}
 

--- a/builder/zstack/driver.go
+++ b/builder/zstack/driver.go
@@ -35,6 +35,8 @@ type Driver interface {
 	DeleteVmInstance(uuid string) error
 
 	CreateImage(rootVolumeUuid string, params param.CreateRootVolumeTemplateFromRootVolumeParam) (*view.ImageInventoryView, error)
+	CreateImageFromVolumeSnapshot(snapshotUuid string, params param.CreateRootVolumeTemplateFromVolumeSnapshotParam) (*view.ImageInventoryView, error)
+	GetVolumeSnapshot(uuid string) (*view.VolumeSnapshotInventoryView, error)
 	AddImage(param param.AddImageParam) (*view.ImageInventoryView, error)
 	DeleteImage(uuid string) error
 	ExpungeImage(uuid string) error
@@ -210,6 +212,28 @@ func (d *ZStackDriver) CreateImage(rootVolumeUuid string, rootVolumeParam param.
 	}
 	log.Printf("[INFO] Successfully created image '%s'", img.UUID)
 	return img, nil
+}
+
+func (d *ZStackDriver) CreateImageFromVolumeSnapshot(snapshotUuid string, snapshotParam param.CreateRootVolumeTemplateFromVolumeSnapshotParam) (*view.ImageInventoryView, error) {
+	log.Printf("[INFO] Creating image from volume snapshot '%s'", snapshotUuid)
+	img, err := d.client.CreateRootVolumeTemplateFromVolumeSnapshot(snapshotUuid, snapshotParam)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create image from volume snapshot '%s': %v", snapshotUuid, err)
+	}
+	log.Printf("[INFO] Successfully created image '%s' from snapshot '%s'", img.UUID, snapshotUuid)
+	return img, nil
+}
+
+func (d *ZStackDriver) GetVolumeSnapshot(uuid string) (*view.VolumeSnapshotInventoryView, error) {
+	log.Printf("[DEBUG] Getting volume snapshot with UUID: %s", uuid)
+	snapshot, err := d.client.GetVolumeSnapshot(uuid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query volume snapshot '%s': %v", uuid, err)
+	}
+	if snapshot == nil {
+		return nil, fmt.Errorf("volume snapshot '%s' not found", uuid)
+	}
+	return snapshot, nil
 }
 
 func (d *ZStackDriver) AddImage(image param.AddImageParam) (*view.ImageInventoryView, error) {

--- a/builder/zstack/mock_driver_test.go
+++ b/builder/zstack/mock_driver_test.go
@@ -87,6 +87,17 @@ type MockDriver struct {
 	CreateImageRootVolumeUuid string
 	CreateImageParam          param.CreateRootVolumeTemplateFromRootVolumeParam
 
+	CreateImageFromSnapshotResult       *view.ImageInventoryView
+	CreateImageFromSnapshotErr          error
+	CreateImageFromSnapshotCalled       bool
+	CreateImageFromSnapshotSnapshotUuid string
+	CreateImageFromSnapshotParam        param.CreateRootVolumeTemplateFromVolumeSnapshotParam
+
+	GetVolumeSnapshotResult *view.VolumeSnapshotInventoryView
+	GetVolumeSnapshotErr    error
+	GetVolumeSnapshotCalled bool
+	GetVolumeSnapshotUuid   string
+
 	AddImageResult *view.ImageInventoryView
 	AddImageErr    error
 	AddImageCalled bool
@@ -204,6 +215,17 @@ func (m *MockDriver) CreateImage(rootVolumeUuid string, params param.CreateRootV
 	m.CreateImageRootVolumeUuid = rootVolumeUuid
 	m.CreateImageParam = params
 	return m.CreateImageResult, m.CreateImageErr
+}
+func (m *MockDriver) CreateImageFromVolumeSnapshot(snapshotUuid string, params param.CreateRootVolumeTemplateFromVolumeSnapshotParam) (*view.ImageInventoryView, error) {
+	m.CreateImageFromSnapshotCalled = true
+	m.CreateImageFromSnapshotSnapshotUuid = snapshotUuid
+	m.CreateImageFromSnapshotParam = params
+	return m.CreateImageFromSnapshotResult, m.CreateImageFromSnapshotErr
+}
+func (m *MockDriver) GetVolumeSnapshot(uuid string) (*view.VolumeSnapshotInventoryView, error) {
+	m.GetVolumeSnapshotCalled = true
+	m.GetVolumeSnapshotUuid = uuid
+	return m.GetVolumeSnapshotResult, m.GetVolumeSnapshotErr
 }
 func (m *MockDriver) AddImage(p param.AddImageParam) (*view.ImageInventoryView, error) {
 	m.AddImageCalled = true

--- a/builder/zstack/step_create_image_from_snapshot.go
+++ b/builder/zstack/step_create_image_from_snapshot.go
@@ -1,0 +1,88 @@
+package zstack
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/zstackio/zstack-sdk-go-v2/pkg/param"
+)
+
+type StepCreateImageFromSnapshot struct{}
+
+func (s *StepCreateImageFromSnapshot) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packersdk.Ui)
+	config := state.Get("config").(*Config)
+	driver := state.Get("driver").(Driver)
+
+	snapshotUuid := config.SourceVolumeSnapshotUuid
+	if snapshotUuid == "" {
+		err := fmt.Errorf("source_volume_snapshot_uuid is empty, cannot create image from snapshot")
+		ui.Error(err.Error())
+		state.Put("error", err)
+		return multistep.ActionHalt
+	}
+
+	if config.BackupStorageUuid == "" {
+		err := fmt.Errorf("backup storage UUID is empty, cannot create image from snapshot")
+		ui.Error(err.Error())
+		state.Put("error", err)
+		return multistep.ActionHalt
+	}
+
+	ui.Say(fmt.Sprintf("Validating volume snapshot '%s'...", snapshotUuid))
+	snapshot, err := driver.GetVolumeSnapshot(snapshotUuid)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Failed to get volume snapshot: %v", err))
+		state.Put("error", err)
+		return multistep.ActionHalt
+	}
+	log.Printf("[INFO] Snapshot %s status=%s state=%s volumeType=%s", snapshot.UUID, snapshot.Status, snapshot.State, snapshot.VolumeType)
+
+	ui.Say(fmt.Sprintf("Creating image '%s' from volume snapshot '%s'...", config.ImageName, snapshotUuid))
+
+	description := config.ImageDescription
+	if description == "" {
+		description = "Auto created by packer-plugin-zstack from volume snapshot"
+	}
+
+	createParam := param.CreateRootVolumeTemplateFromVolumeSnapshotParam{
+		BaseParam: param.BaseParam{},
+		Params: param.CreateRootVolumeTemplateFromVolumeSnapshotParamDetail{
+			Name:               config.ImageName,
+			Description:        &description,
+			BackupStorageUuids: []string{config.BackupStorageUuid},
+		},
+	}
+	if config.GuestOsType != "" {
+		gos := config.GuestOsType
+		createParam.Params.GuestOsType = &gos
+	}
+	if config.Platform != "" {
+		platform := config.Platform
+		createParam.Params.Platform = &platform
+	}
+	if config.Architecture != "" {
+		arch := config.Architecture
+		createParam.Params.Architecture = &arch
+	}
+
+	image, err := driver.CreateImageFromVolumeSnapshot(snapshotUuid, createParam)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Failed to create image from snapshot: %v", err))
+		log.Printf("[ERROR] Failed to create image from snapshot %s: %v", snapshotUuid, err)
+		state.Put("error", err)
+		return multistep.ActionHalt
+	}
+
+	config.ImageUuid = image.UUID
+	state.Put("config", config)
+
+	log.Printf("[INFO] Successfully created image with UUID: %s from snapshot %s", image.UUID, snapshotUuid)
+	ui.Say(fmt.Sprintf("Successfully created image '%s' (UUID: %s) from snapshot %s", config.ImageName, image.UUID, snapshotUuid))
+	return multistep.ActionContinue
+}
+
+func (s *StepCreateImageFromSnapshot) Cleanup(state multistep.StateBag) {}

--- a/builder/zstack/step_create_image_from_snapshot_test.go
+++ b/builder/zstack/step_create_image_from_snapshot_test.go
@@ -1,0 +1,178 @@
+package zstack
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	"github.com/stretchr/testify/assert"
+	"github.com/zstackio/zstack-sdk-go-v2/pkg/view"
+)
+
+func TestStepCreateImageFromSnapshot_Run(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		config := &Config{
+			ImageConfig: ImageConfig{
+				ImageName:                "img-from-snap",
+				SourceVolumeSnapshotUuid: "snap-uuid-1",
+				Platform:                 "Linux",
+				GuestOsType:              "Ubuntu 22.04",
+				Architecture:             "x86_64",
+				ImageDescription:         "from snapshot",
+			},
+			BackupStorageConfig: BackupStorageConfig{BackupStorageUuid: "bs-1"},
+		}
+		driver := &MockDriver{
+			GetVolumeSnapshotResult:       &view.VolumeSnapshotInventoryView{BaseInfoView: view.BaseInfoView{UUID: "snap-uuid-1"}, Status: "Ready", State: "Enabled"},
+			CreateImageFromSnapshotResult: &view.ImageInventoryView{BaseInfoView: view.BaseInfoView{UUID: "img-uuid-1"}},
+		}
+		state := testStateBag(config, driver)
+
+		action := (&StepCreateImageFromSnapshot{}).Run(context.Background(), state)
+
+		assert.Equal(t, multistep.ActionContinue, action)
+		assert.True(t, driver.GetVolumeSnapshotCalled)
+		assert.Equal(t, "snap-uuid-1", driver.GetVolumeSnapshotUuid)
+		assert.True(t, driver.CreateImageFromSnapshotCalled)
+		assert.Equal(t, "snap-uuid-1", driver.CreateImageFromSnapshotSnapshotUuid)
+		assert.Equal(t, []string{"bs-1"}, driver.CreateImageFromSnapshotParam.Params.BackupStorageUuids)
+		assert.Equal(t, "img-from-snap", driver.CreateImageFromSnapshotParam.Params.Name)
+		if assert.NotNil(t, driver.CreateImageFromSnapshotParam.Params.Platform) {
+			assert.Equal(t, "Linux", *driver.CreateImageFromSnapshotParam.Params.Platform)
+		}
+		if assert.NotNil(t, driver.CreateImageFromSnapshotParam.Params.GuestOsType) {
+			assert.Equal(t, "Ubuntu 22.04", *driver.CreateImageFromSnapshotParam.Params.GuestOsType)
+		}
+		if assert.NotNil(t, driver.CreateImageFromSnapshotParam.Params.Architecture) {
+			assert.Equal(t, "x86_64", *driver.CreateImageFromSnapshotParam.Params.Architecture)
+		}
+		if assert.NotNil(t, driver.CreateImageFromSnapshotParam.Params.Description) {
+			assert.Equal(t, "from snapshot", *driver.CreateImageFromSnapshotParam.Params.Description)
+		}
+		assert.Equal(t, "img-uuid-1", config.ImageUuid)
+	})
+
+	t.Run("MissingSnapshotUuid", func(t *testing.T) {
+		config := &Config{
+			ImageConfig:         ImageConfig{ImageName: "img"},
+			BackupStorageConfig: BackupStorageConfig{BackupStorageUuid: "bs-1"},
+		}
+		driver := &MockDriver{}
+		state := testStateBag(config, driver)
+
+		action := (&StepCreateImageFromSnapshot{}).Run(context.Background(), state)
+
+		assert.Equal(t, multistep.ActionHalt, action)
+		_, ok := state.GetOk("error")
+		assert.True(t, ok)
+		assert.False(t, driver.CreateImageFromSnapshotCalled)
+	})
+
+	t.Run("MissingBackupStorage", func(t *testing.T) {
+		config := &Config{
+			ImageConfig: ImageConfig{ImageName: "img", SourceVolumeSnapshotUuid: "snap-1"},
+		}
+		driver := &MockDriver{}
+		state := testStateBag(config, driver)
+
+		action := (&StepCreateImageFromSnapshot{}).Run(context.Background(), state)
+
+		assert.Equal(t, multistep.ActionHalt, action)
+		_, ok := state.GetOk("error")
+		assert.True(t, ok)
+		assert.False(t, driver.CreateImageFromSnapshotCalled)
+	})
+
+	t.Run("GetSnapshotError", func(t *testing.T) {
+		expectedErr := errors.New("snapshot not found")
+		config := &Config{
+			ImageConfig:         ImageConfig{ImageName: "img", SourceVolumeSnapshotUuid: "snap-1"},
+			BackupStorageConfig: BackupStorageConfig{BackupStorageUuid: "bs-1"},
+		}
+		driver := &MockDriver{GetVolumeSnapshotErr: expectedErr}
+		state := testStateBag(config, driver)
+
+		action := (&StepCreateImageFromSnapshot{}).Run(context.Background(), state)
+
+		assert.Equal(t, multistep.ActionHalt, action)
+		errVal, ok := state.GetOk("error")
+		assert.True(t, ok)
+		assert.Equal(t, expectedErr, errVal)
+		assert.False(t, driver.CreateImageFromSnapshotCalled)
+	})
+
+	t.Run("CreateImageError", func(t *testing.T) {
+		expectedErr := errors.New("create failed")
+		config := &Config{
+			ImageConfig:         ImageConfig{ImageName: "img", SourceVolumeSnapshotUuid: "snap-1"},
+			BackupStorageConfig: BackupStorageConfig{BackupStorageUuid: "bs-1"},
+		}
+		driver := &MockDriver{
+			GetVolumeSnapshotResult:    &view.VolumeSnapshotInventoryView{BaseInfoView: view.BaseInfoView{UUID: "snap-1"}, Status: "Ready"},
+			CreateImageFromSnapshotErr: expectedErr,
+		}
+		state := testStateBag(config, driver)
+
+		action := (&StepCreateImageFromSnapshot{}).Run(context.Background(), state)
+
+		assert.Equal(t, multistep.ActionHalt, action)
+		errVal, ok := state.GetOk("error")
+		assert.True(t, ok)
+		assert.Equal(t, expectedErr, errVal)
+	})
+
+	t.Run("DefaultDescription", func(t *testing.T) {
+		config := &Config{
+			ImageConfig:         ImageConfig{ImageName: "img", SourceVolumeSnapshotUuid: "snap-1"},
+			BackupStorageConfig: BackupStorageConfig{BackupStorageUuid: "bs-1"},
+		}
+		driver := &MockDriver{
+			GetVolumeSnapshotResult:       &view.VolumeSnapshotInventoryView{BaseInfoView: view.BaseInfoView{UUID: "snap-1"}, Status: "Ready"},
+			CreateImageFromSnapshotResult: &view.ImageInventoryView{BaseInfoView: view.BaseInfoView{UUID: "img-uuid-1"}},
+		}
+		state := testStateBag(config, driver)
+
+		action := (&StepCreateImageFromSnapshot{}).Run(context.Background(), state)
+
+		assert.Equal(t, multistep.ActionContinue, action)
+		if assert.NotNil(t, driver.CreateImageFromSnapshotParam.Params.Description) {
+			assert.Equal(t, "Auto created by packer-plugin-zstack from volume snapshot", *driver.CreateImageFromSnapshotParam.Params.Description)
+		}
+	})
+}
+
+func TestConfigPrepare_SnapshotMode(t *testing.T) {
+	t.Run("MissingImageName", func(t *testing.T) {
+		c := &Config{
+			AccessConfig: AccessConfig{Host: "h", AccountName: "a", AccountPassword: "p"},
+			ImageConfig:  ImageConfig{SourceVolumeSnapshotUuid: "snap-1"},
+		}
+		err := c.Prepare()
+		if assert.Error(t, err) {
+			assert.Contains(t, err.Error(), "image_name")
+		}
+	})
+
+	t.Run("MissingBackupStorage", func(t *testing.T) {
+		c := &Config{
+			AccessConfig: AccessConfig{Host: "h", AccountName: "a", AccountPassword: "p"},
+			ImageConfig:  ImageConfig{SourceVolumeSnapshotUuid: "snap-1", ImageName: "img"},
+		}
+		err := c.Prepare()
+		if assert.Error(t, err) {
+			assert.Contains(t, err.Error(), "backup_storage")
+		}
+	})
+
+	t.Run("Valid", func(t *testing.T) {
+		c := &Config{
+			AccessConfig:        AccessConfig{Host: "h", AccountName: "a", AccountPassword: "p"},
+			ImageConfig:         ImageConfig{SourceVolumeSnapshotUuid: "snap-1", ImageName: "img"},
+			BackupStorageConfig: BackupStorageConfig{BackupStorageName: "bs"},
+		}
+		err := c.Prepare()
+		assert.NoError(t, err)
+		assert.Equal(t, "Linux", c.Platform)
+	})
+}

--- a/builder/zstack/step_pre_validate.go
+++ b/builder/zstack/step_pre_validate.go
@@ -18,8 +18,11 @@ func (s *StepPreValidate) Run(ctx context.Context, state multistep.StateBag) mul
 	config := state.Get("config").(*Config)
 	ui.Say("Validating configuration...")
 
-	// AC-002-02: Skip network query when network_uuid is provided
-	if config.NetworkConfig.L3NetworkUuid != "" {
+	snapshotOnly := config.SourceVolumeSnapshotUuid != ""
+
+	if snapshotOnly {
+		log.Printf("[INFO] Snapshot-only build: skipping L3 network validation")
+	} else if config.NetworkConfig.L3NetworkUuid != "" {
 		log.Printf("[INFO] Using provided network UUID: %s", config.NetworkConfig.L3NetworkUuid)
 		ui.Say(fmt.Sprintf("Using provided network UUID: %s", config.NetworkConfig.L3NetworkUuid))
 	} else {
@@ -35,6 +38,12 @@ func (s *StepPreValidate) Run(ctx context.Context, state multistep.StateBag) mul
 	// source_image_url imports require backup storage for image download/import.
 	if config.SourceImageUrl != "" && config.BackupStorageConfig.BackupStorageUuid == "" && config.BackupStorageConfig.BackupStorageName == "" {
 		err := fmt.Errorf("backup_storage_name or backup_storage_uuid is required when source_image_url is set")
+		ui.Errorf("Backup storage validation failed: %s", err)
+		return multistep.ActionHalt
+	}
+
+	if snapshotOnly && config.BackupStorageConfig.BackupStorageUuid == "" && config.BackupStorageConfig.BackupStorageName == "" {
+		err := fmt.Errorf("backup_storage_name or backup_storage_uuid is required when source_volume_snapshot_uuid is set")
 		ui.Errorf("Backup storage validation failed: %s", err)
 		return multistep.ActionHalt
 	}

--- a/docs/builders/builder.mdx
+++ b/docs/builders/builder.mdx
@@ -40,9 +40,13 @@ The zstack builder is used to create ZStack Image by VM Instance
 
 - `guest_os_type` (String) - Guest OS type, such as "Ubuntu", "CentOS", etc.
 
+- `architecture` (String) - CPU architecture of the image, such as "x86_64", "aarch64".
+
 - `image_name` (String) - Name of the target image to be created.
 
 - `image_description` (String) - Description for the created image. Defaults to the image name if not set.
+
+- `source_volume_snapshot_uuid` (String) - UUID of an existing ZStack volume snapshot. When set, the builder creates a root volume template directly from the snapshot and skips VM creation, SSH connection, and provisioners. Requires `image_name` and one of `backup_storage_name` / `backup_storage_uuid`.
 
 **Network Parameters**
 
@@ -105,4 +109,28 @@ source "zstack" "example" {
   ssh_password = "your-ssh-password"
 }
 
+```
+
+### Example: Build From Volume Snapshot
+
+Skip VM creation entirely and build an image directly from an existing volume snapshot. No SSH connection or provisioners are required:
+
+```hcl
+source "zstack" "from_snapshot" {
+  zstack_host      = "https://zstack.example.com"
+  account_name     = env("ZSTACK_ACCOUNT_NAME")
+  account_password = env("ZSTACK_ACCOUNT_PASSWORD")
+
+  source_volume_snapshot_uuid = "snapshot-uuid-here"
+
+  image_name          = "packer-from-snapshot-image"
+  image_description   = "Built from ZStack volume snapshot"
+  platform            = "Linux"
+  architecture        = "x86_64"
+  backup_storage_name = "local-backup"
+}
+
+build {
+  sources = ["source.zstack.from_snapshot"]
+}
 ```

--- a/example/from_snapshot.pkr.hcl
+++ b/example/from_snapshot.pkr.hcl
@@ -1,0 +1,48 @@
+# Build an image directly from an existing ZStack volume snapshot (no VM/SSH/provisioning).
+variable "zstack_host" {
+  type    = string
+  default = env("ZSTACK_HOST")
+}
+
+variable "account_name" {
+  type    = string
+  default = env("ZSTACK_ACCOUNT_NAME")
+}
+
+variable "account_password" {
+  type      = string
+  sensitive = true
+  default   = env("ZSTACK_ACCOUNT_PASSWORD")
+}
+
+variable "snapshot_uuid" {
+  type        = string
+  description = "UUID of the volume snapshot to convert into an image"
+}
+
+packer {
+  required_plugins {
+    zstack = {
+      version = ">= 2.0.0"
+      source  = "github.com/zstackio/zstack"
+    }
+  }
+}
+
+source "zstack" "from_snapshot" {
+  zstack_host      = var.zstack_host
+  account_name     = var.account_name
+  account_password = var.account_password
+
+  source_volume_snapshot_uuid = var.snapshot_uuid
+
+  image_name          = "packer-from-snapshot-image"
+  image_description   = "Built with Packer from a ZStack volume snapshot"
+  platform            = "Linux"
+  architecture        = "x86_64"
+  backup_storage_name = "local-backup"
+}
+
+build {
+  sources = ["source.zstack.from_snapshot"]
+}


### PR DESCRIPTION
Add a snapshot-only build path that creates a root volume template directly from an existing ZStack volume snapshot, skipping VM creation, SSH, and provisioners. Introduces source_volume_snapshot_uuid and architecture config fields, new driver methods (CreateImageFromVolumeSnapshot, GetVolumeSnapshot), a StepCreateImageFromSnapshot step with tests, and docs/examples.