### PR TITLE
fix: reset portEnvErr on each applyEnvDefaults call

### DIFF
--- a/builder/zstack/access_config.go
+++ b/builder/zstack/access_config.go
@@ -32,6 +32,9 @@ func getEnvOrDefault(envVar string, defaultValue string) string {
 }
 
 func (c *AccessConfig) applyEnvDefaults() {
+	// Reset transient env-parse state so repeated Prepare() calls don't see
+	// a stale error from a previous invocation with a bad ZSTACK_PORT.
+	c.portEnvErr = nil
 	c.Host = getEnvOrDefault("ZSTACK_HOST", c.Host)
 	if raw := os.Getenv("ZSTACK_PORT"); raw != "" {
 		p, err := strconv.Atoi(raw)


### PR DESCRIPTION
## Summary
- Clear `AccessConfig.portEnvErr` at the start of `applyEnvDefaults()` so a bad `ZSTACK_PORT` detected on a previous `Prepare()` call cannot leak into a later preparation on the same config instance.
- Addresses P2 finding from QA review: the stale error could have caused false validation failures after the user fixed/unset `ZSTACK_PORT`.

## Test plan
- [x] `go vet ./builder/zstack/...`
- [x] `go test ./builder/zstack/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)