### PR TITLE
chore: QA cleanup, copyright headers, and i18n docs

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,6 +1,7 @@
 project {
-  license = "MPL-2.0"
-  copyright_year = 2013
+  license          = "MPL-2.0"
+  copyright_holder = "ZStack.io, Inc."
+  copyright_year   = 2013
   header_ignore = [
    ".goreleaser.yml"
   ]

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ docs/stories/**
 docs/epic-automation_iac.md
 example/local-dev.pkr.hcl
 
+# locally built plugin binaries (packer init test layout)
+github.com/
+
 # local/private config
 .env
 .env.*

--- a/.web-docs/components/builder/builder/README.md
+++ b/.web-docs/components/builder/builder/README.md
@@ -79,7 +79,7 @@
 
 ```hcl
 source "zstack" "example" {
-  zstack_host       = "https://zstack.example.com"
+  zstack_host       = "zstack.example.com"
   access_key_id     = env("ZSTACK_ACCESS_KEY_ID")
   access_key_secret = env("ZSTACK_ACCESS_KEY_SECRET")
 

--- a/.web-docs/components/builder/zstack/README.md
+++ b/.web-docs/components/builder/zstack/README.md
@@ -63,10 +63,10 @@
 
 ```hcl
 source "zstack" "test" {
-  zstack_host       = "10.3.3.3"
+  zstack_host       = "zstack.example.com"
   port             = 8080
-  access_key_id     = "aaaaaaa"
-  access_key_secret = "1UQ3bfz9qS4vaaaaaaaaa"
+  access_key_id     = "your-access-key-id"
+  access_key_secret = "your-access-key-secret"
   
   source_image      = "Centos8"
   source_image_url  = "http://example.com/image.qcow2"
@@ -80,7 +80,7 @@ source "zstack" "test" {
   image_name       = "image-by-packer"
   
   ssh_username     = "root"
-  ssh_password     = "password"
+  ssh_password     = "your-ssh-password"
 }
 
 ```

--- a/.web-docs/metadata.hcl
+++ b/.web-docs/metadata.hcl
@@ -1,4 +1,4 @@
-# Copyright (c) ZStack.io, Inc.
+# Copyright ZStack.io, Inc. 2013, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 

--- a/.web-docs/scripts/compile-to-webdocs.sh
+++ b/.web-docs/scripts/compile-to-webdocs.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) HashiCorp, Inc.
+# Copyright ZStack.io, Inc. 2013, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 

--- a/README.md
+++ b/README.md
@@ -35,17 +35,17 @@ The plugin supports two authentication methods:
 
 You can build from resource names or use UUID passthrough with `image_uuid`, `network_uuid`, and `instance_offering_uuid` to skip name-based lookups.
 
-Optional backup storage settings let you export the resulting image when `backup_storage_name` or `backup_storage_uuid` is configured; if neither is set, the export step is skipped.
+Backup storage is required for image creation. The builder uses it when creating the image template from a volume snapshot, whether the snapshot is supplied explicitly via `source_volume_snapshot_uuid` or created automatically from the VM root volume during a normal build.
 
 Use `image_description` to set a custom description for the generated image.
 
-The plugin also supports building an image directly from an existing **volume snapshot** by setting `source_volume_snapshot_uuid`. In this mode no VM is created and SSH/provisioners are skipped — see [`example/from_snapshot.pkr.hcl`](example/from_snapshot.pkr.hcl).
+The plugin also supports building an image directly from an existing **volume snapshot** by setting `source_volume_snapshot_uuid`. In this mode no VM is created and SSH/provisioners are skipped; the builder creates the image template from that existing snapshot — see [`example/from_snapshot.pkr.hcl`](example/from_snapshot.pkr.hcl).
 
 See the [`example/`](example) directory for ready-to-run HCL examples covering account/password auth, AK/SK auth, and UUID passthrough.
 
 ## E2E Test Method
 
-Use the local E2E template and shell script to verify the full build flow (image import, VM create, SSH provision, image create):
+Use the local E2E template and shell script to verify the full build flow (image import, VM create, SSH provision, root-volume snapshot create, image create from snapshot):
 
 - Template: [`example/local-dev.pkr.hcl`](example/local-dev.pkr.hcl)
 - Provisioner script: [`example/load_images.sh`](example/load_images.sh)
@@ -92,9 +92,9 @@ PACKER_PLUGIN_PATH=$(pwd) packer validate example/local-dev.pkr.hcl
 PACKER_PLUGIN_PATH=$(pwd) packer build example/local-dev.pkr.hcl
 ```
 
-### Export Behavior
+### Backup Storage / Export Behavior
 
-- If `backup_storage_name`/`backup_storage_uuid` is missing while `source_image_url` is set, validation fails early.
+- `backup_storage_name` or `backup_storage_uuid` is required for both normal VM builds and `source_volume_snapshot_uuid` builds, because image creation now runs through the snapshot-to-template flow.
 - If backup storage does not support image export, export is skipped with a warning instead of failing the entire build.
 
 ### Configuration

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,0 +1,248 @@
+# Packer Plugin ZStack（中文）
+
+`ZStack` 是一个 HashiCorp [Packer](https://www.packer.io) 多组件插件，用于基于 ZStack 云平台的 VM 实例或卷快照构建自定义镜像。完整的功能列表请参见 [docs](docs)。
+
+> English version: see [README.md](README.md)。
+
+## 功能概览
+
+- **两种构建路径**
+  - VM 构建：导入/选择源镜像 → 创建 VM → SSH 连接 → 执行 provisioner → 关机 → 创建快照 → 生成镜像 → 导出
+  - 快照直接构建（设置 `source_volume_snapshot_uuid`）：跳过 VM 创建、SSH 与 provisioner，直接基于已有卷快照生成镜像模板
+- **两种鉴权方式**
+  - 账号密码：`account_name` + `account_password`
+  - AccessKey（推荐）：`access_key_id` + `access_key_secret`
+- **多种镜像源**：已有镜像名 / `image_uuid` 直传 / `source_image_url` 从 HTTP(S) 远程导入
+- **网络与规格**：支持名称解析为 UUID，或直接传入 `network_uuid` / `instance_offering_uuid`；可用 `cpu_num` + `memory_size` 替代实例规格
+- **可配置超时**：`image_ready_timeout`、`vm_running_timeout`
+- **导出兼容**：备份存储不支持镜像导出时降级为告警，不会让整个构建失败
+- **敏感信息脱敏**：日志摘要只输出 `*_set=true/false` 而不会泄漏密钥/密码
+
+## 安装
+
+### 使用 `packer init`
+
+从 Packer 1.7 开始可用：
+
+```hcl
+packer {
+  required_plugins {
+    zstack = {
+      version = ">= 2.0.0"
+      source  = "github.com/zstackio/zstack"
+    }
+  }
+}
+```
+
+随后执行 `packer init`。
+
+## 鉴权环境变量
+
+| 变量 | 说明 |
+| --- | --- |
+| `ZSTACK_HOST` | 管理节点地址（必填） |
+| `ZSTACK_PORT` | 管理节点端口（默认 8080） |
+| `ZSTACK_ACCOUNT_NAME` / `ZSTACK_ACCOUNT_PASSWORD` | 账号密码方式 |
+| `ZSTACK_ACCESS_KEY_ID` / `ZSTACK_ACCESS_KEY_SECRET` | AccessKey 方式（推荐） |
+
+两种方式互斥，只能配置其一。
+
+## 快速开始
+
+### 1. 基于已有镜像构建
+
+```hcl
+source "zstack" "example" {
+  zstack_host       = "zstack.example.com"
+  access_key_id     = env("ZSTACK_ACCESS_KEY_ID")
+  access_key_secret = env("ZSTACK_ACCESS_KEY_SECRET")
+
+  source_image           = "ubuntu-22.04"
+  network_name           = "default-network"
+  instance_offering_name = "medium-vm"
+  backup_storage_name    = "local-backup"
+
+  instance_name     = "packer-example"
+  image_name        = "packer-example-image"
+  image_description = "Built by Packer"
+
+  ssh_username = "root"
+  ssh_password = "your-ssh-password"
+}
+
+build {
+  sources = ["source.zstack.example"]
+
+  provisioner "shell" {
+    inline = ["echo hello"]
+  }
+}
+```
+
+### 2. 从远程 URL 导入并构建
+
+```hcl
+source "zstack" "from_url" {
+  zstack_host      = "zstack.example.com"
+  account_name     = env("ZSTACK_ACCOUNT_NAME")
+  account_password = env("ZSTACK_ACCOUNT_PASSWORD")
+
+  source_image     = "ubuntu-22.04-from-url"
+  source_image_url = "http://mirrors.example.com/ubuntu-22.04.qcow2"
+  format           = "qcow2"     # 默认 qcow2
+  platform         = "Linux"     # 默认 Linux
+  guest_os_type    = "Ubuntu"
+
+  network_name        = "default-network"
+  cpu_num             = 2
+  memory_size         = 4096
+  backup_storage_name = "local-backup"
+
+  instance_name = "packer-from-url"
+  image_name    = "packer-from-url-image"
+  ssh_username  = "root"
+  ssh_password  = "your-ssh-password"
+}
+```
+
+### 3. UUID 直通模式（跳过名称查询）
+
+```hcl
+source "zstack" "uuid_passthrough" {
+  zstack_host       = "zstack.example.com"
+  access_key_id     = env("ZSTACK_ACCESS_KEY_ID")
+  access_key_secret = env("ZSTACK_ACCESS_KEY_SECRET")
+
+  image_uuid             = "xxxxxxxx-image-uuid-xxxxxxxx"
+  network_uuid           = "xxxxxxxx-net-uuid-xxxxxxxx"
+  instance_offering_uuid = "xxxxxxxx-offer-uuid-xxxxxxxx"
+  backup_storage_uuid    = "xxxxxxxx-bs-uuid-xxxxxxxx"
+
+  instance_name = "packer-uuid"
+  image_name    = "packer-uuid-image"
+  ssh_username  = "root"
+  ssh_password  = "your-ssh-password"
+}
+```
+
+### 4. 从已有卷快照构建（跳过 VM/SSH）
+
+```hcl
+source "zstack" "from_snapshot" {
+  zstack_host      = "zstack.example.com"
+  account_name     = env("ZSTACK_ACCOUNT_NAME")
+  account_password = env("ZSTACK_ACCOUNT_PASSWORD")
+
+  source_volume_snapshot_uuid = "snapshot-uuid-here"
+
+  image_name          = "packer-from-snapshot"
+  image_description   = "Built from ZStack volume snapshot"
+  platform            = "Linux"
+  architecture        = "x86_64"
+  backup_storage_name = "local-backup"
+}
+
+build {
+  sources = ["source.zstack.from_snapshot"]
+}
+```
+
+> 该模式下 Packer 不会创建 VM，也不会建立 SSH 连接、不会执行 provisioner。
+
+## 配置项参考
+
+### 鉴权（必填一组）
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `zstack_host` | string | 管理节点 URL，必填 |
+| `port` | int | 管理节点端口，默认 8080 |
+| `account_name` / `account_password` | string | 账号密码（仅支持平台管理员 `admin`） |
+| `access_key_id` / `access_key_secret` | string | AccessKey 方式（推荐） |
+
+### 镜像参数
+
+| 字段 | 说明 |
+| --- | --- |
+| `source_image` | 源镜像名称 |
+| `image_uuid` | 源镜像 UUID（提供后跳过名称查询） |
+| `source_image_url` | HTTP/HTTPS 远程镜像 URL |
+| `format` | 镜像格式（qcow2、raw 等，默认 qcow2） |
+| `platform` | 平台类型（Linux/Windows，默认 Linux） |
+| `guest_os_type` | 客户机 OS 类型（Ubuntu、CentOS …） |
+| `architecture` | CPU 架构（x86_64、aarch64） |
+| `image_name` | 目标镜像名称 |
+| `image_description` | 目标镜像描述（默认与名称相同） |
+| `source_volume_snapshot_uuid` | 已有卷快照 UUID，启用快照直建模式 |
+
+### 网络与实例
+
+| 字段 | 说明 |
+| --- | --- |
+| `network_name` / `network_uuid` | L3 网络名或 UUID |
+| `instance_offering_name` / `instance_offering_uuid` | 实例规格 |
+| `cpu_num` / `memory_size` | 自定义 CPU / 内存（MB），可替代实例规格 |
+| `instance_name` | 临时 VM 名称 |
+
+### 备份存储
+
+| 字段 | 说明 |
+| --- | --- |
+| `backup_storage_name` / `backup_storage_uuid` | 镜像存放的备份存储；**两者至少配置一个** |
+
+### SSH（仅常规构建路径需要）
+
+| 字段 | 说明 |
+| --- | --- |
+| `ssh_username` | SSH 用户名 |
+| `ssh_password` | SSH 密码 |
+
+### 超时
+
+| 字段 | 默认值 | 说明 |
+| --- | --- | --- |
+| `image_ready_timeout` | `5m` | 等待镜像变为 Ready 状态的最长时间 |
+| `vm_running_timeout` | `5m` | 等待 VM 进入 Running 状态的最长时间 |
+
+## 构建步骤说明
+
+**常规构建路径：**
+
+```
+StepPreValidate → StepAddImage（仅 source_image_url）→ StepWaitForImageReady
+                → StepSourceImageValidate（仅命名/UUID 模式）
+                → StepInstanceOfferingValidate（可选）
+                → StepCreateSSHKey → StepCreateVMInstance → StepWaitForRunning
+                → StepAttachGuestTools → StepConnect → StepProvision
+                → StepStopVmInstance → StepCreateImage → StepExpungeVmInstance
+                → StepExportImage
+```
+
+**快照直建路径：**
+
+```
+StepPreValidate → StepCreateImageFromSnapshot → StepWaitForImageReady → StepExportImage
+```
+
+## E2E 测试
+
+参考 [`example/local-dev.pkr.hcl`](example/local-dev.pkr.hcl) 与 [`example/load_images.sh`](example/load_images.sh)。
+
+```bash
+PACKER_PLUGIN_PATH=$(pwd) packer validate example/local-dev.pkr.hcl
+PACKER_PLUGIN_PATH=$(pwd) packer build    example/local-dev.pkr.hcl
+```
+
+> **建议**：`source_image_url` 模式下，备份存储优先用 `backup_storage_name`，插件会自动解析为 UUID，免去记忆 UUID。
+
+## 行为约定
+
+- 备份存储参数必填（无论是常规构建还是快照构建），因为镜像通过 “快照 → 模板” 流程产生。
+- 备份存储不支持导出时，构建会跳过导出步骤并打印警告，整个构建仍判定为成功。
+- 创建临时 SSH 密钥仅在 `ssh_password` 与 `ssh_private_key_file` 都未提供时发生，密钥仅保留在内存中。
+
+## 贡献
+
+- 发现 Bug 或对使用有疑问，请在 GitHub Issue 中反馈。
+- 欢迎 PR；功能性改动请先开 Issue 讨论。

--- a/builder/zstack/access_config.go
+++ b/builder/zstack/access_config.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (
@@ -5,12 +8,15 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 	"github.com/zstackio/zstack-sdk-go-v2/pkg/client"
 	"github.com/zstackio/zstack-sdk-go-v2/pkg/param"
 )
+
+const defaultClientLoginTimeout = 30 * time.Second
 
 type AccessConfig struct {
 	Host            string `mapstructure:"zstack_host"`
@@ -92,7 +98,7 @@ func (c *AccessConfig) Prepare(raws ...interface{}) []error {
 	return nil
 }
 
-func (c *AccessConfig) CreateClient() (*client.ZSClient, error) {
+func (c *AccessConfig) CreateClient(debug bool) (*client.ZSClient, error) {
 	var cli *client.ZSClient
 
 	// PKR-001 Bug 1: Only set default port when not specified (was overwriting custom port)
@@ -100,14 +106,17 @@ func (c *AccessConfig) CreateClient() (*client.ZSClient, error) {
 		c.Port = 8080
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), defaultClientLoginTimeout)
+	defer cancel()
+
 	if c.AccountName != "" && c.AccountPassword != "" {
-		cli = client.NewZSClient(client.NewZSConfig(c.Host, c.Port, "zstack").LoginAccount(c.AccountName, c.AccountPassword).ReadOnly(false).Debug(false))
-		_, err := cli.Login(context.Background())
+		cli = client.NewZSClient(client.NewZSConfig(c.Host, c.Port, "zstack").LoginAccount(c.AccountName, c.AccountPassword).ReadOnly(false).Debug(debug))
+		_, err := cli.Login(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create ZStack API client: %s", err)
 		}
 	} else if c.AccessKeyId != "" && c.AccessKeySecret != "" {
-		cli = client.NewZSClient(client.NewZSConfig(c.Host, c.Port, "zstack").AccessKey(c.AccessKeyId, c.AccessKeySecret).ReadOnly(false).Debug(false))
+		cli = client.NewZSClient(client.NewZSConfig(c.Host, c.Port, "zstack").AccessKey(c.AccessKeyId, c.AccessKeySecret).ReadOnly(false).Debug(debug))
 		probe := param.NewQueryParam()
 		if _, err := cli.QueryZone(&probe); err != nil {
 			return nil, fmt.Errorf("unable to validate ZStack access key credentials: %s", err)
@@ -121,8 +130,8 @@ func (c *AccessConfig) CreateClient() (*client.ZSClient, error) {
 	return cli, nil
 }
 
-func (c *AccessConfig) Driver() (*ZStackDriver, error) {
-	cli, err := c.CreateClient()
+func (c *AccessConfig) Driver(debug bool) (*ZStackDriver, error) {
+	cli, err := c.CreateClient(debug)
 	if err != nil {
 		return nil, err
 	}

--- a/builder/zstack/access_config_test.go
+++ b/builder/zstack/access_config_test.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (

--- a/builder/zstack/artifact.go
+++ b/builder/zstack/artifact.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import "fmt"

--- a/builder/zstack/artifact_test.go
+++ b/builder/zstack/artifact_test.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (

--- a/builder/zstack/builder.go
+++ b/builder/zstack/builder.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (
@@ -49,7 +52,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	b.ui = ui
 	log.Printf("[DEBUG] Starting build with %s", b.config.RedactedSummary())
 
-	driver, err := b.config.AccessConfig.Driver()
+	driver, err := b.config.AccessConfig.Driver(b.config.PackerDebug)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize ZStack Driver: %v", err)
 	}

--- a/builder/zstack/builder.hcl2spec.go
+++ b/builder/zstack/builder.hcl2spec.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (
@@ -41,20 +44,20 @@ type FlatConfig struct {
 	BackupStorageName    *string `mapstructure:"backup_storage_name" cty:"backup_storage_name" hcl:"backup_storage_name"`
 	BackupStorageUuid    *string `mapstructure:"backup_storage_uuid" cty:"backup_storage_uuid" hcl:"backup_storage_uuid"`
 
-	SSHHost                *string `mapstructure:"ssh_host" cty:"ssh_host" hcl:"ssh_host"`
-	SSHPort                *int    `mapstructure:"ssh_port" cty:"ssh_port" hcl:"ssh_port"`
-	SSHUsername            *string `mapstructure:"ssh_username" cty:"ssh_username" hcl:"ssh_username"`
-	SSHPassword            *string `mapstructure:"ssh_password" cty:"ssh_password" hcl:"ssh_password"`
-	SSHTimeout             *string `mapstructure:"ssh_timeout" cty:"ssh_timeout" hcl:"ssh_timeout"`
-	SSHHandshakeAttempts   *int    `mapstructure:"ssh_handshake_attempts" cty:"ssh_handshake_attempts" hcl:"ssh_handshake_attempts"`
-	SSHPrivateKeyFile      *string `mapstructure:"ssh_private_key_file" cty:"ssh_private_key_file" hcl:"ssh_private_key_file"`
-	SSHAgentAuth           *bool   `mapstructure:"ssh_agent_auth" cty:"ssh_agent_auth" hcl:"ssh_agent_auth"`
-	SSHKeepAliveInterval   *string `mapstructure:"ssh_keep_alive_interval" cty:"ssh_keep_alive_interval" hcl:"ssh_keep_alive_interval"`
-	SSHReadWriteTimeout    *string `mapstructure:"ssh_read_write_timeout" cty:"ssh_read_write_timeout" hcl:"ssh_read_write_timeout"`
-	Communicator           *string `mapstructure:"communicator" cty:"communicator" hcl:"communicator"`
-	WinRMUser              *string `mapstructure:"winrm_username" cty:"winrm_username" hcl:"winrm_username"`
-	WinRMPassword          *string `mapstructure:"winrm_password" cty:"winrm_password" hcl:"winrm_password"`
-	WinRMTimeout           *string `mapstructure:"winrm_timeout" cty:"winrm_timeout" hcl:"winrm_timeout"`
+	SSHHost              *string `mapstructure:"ssh_host" cty:"ssh_host" hcl:"ssh_host"`
+	SSHPort              *int    `mapstructure:"ssh_port" cty:"ssh_port" hcl:"ssh_port"`
+	SSHUsername          *string `mapstructure:"ssh_username" cty:"ssh_username" hcl:"ssh_username"`
+	SSHPassword          *string `mapstructure:"ssh_password" cty:"ssh_password" hcl:"ssh_password"`
+	SSHTimeout           *string `mapstructure:"ssh_timeout" cty:"ssh_timeout" hcl:"ssh_timeout"`
+	SSHHandshakeAttempts *int    `mapstructure:"ssh_handshake_attempts" cty:"ssh_handshake_attempts" hcl:"ssh_handshake_attempts"`
+	SSHPrivateKeyFile    *string `mapstructure:"ssh_private_key_file" cty:"ssh_private_key_file" hcl:"ssh_private_key_file"`
+	SSHAgentAuth         *bool   `mapstructure:"ssh_agent_auth" cty:"ssh_agent_auth" hcl:"ssh_agent_auth"`
+	SSHKeepAliveInterval *string `mapstructure:"ssh_keep_alive_interval" cty:"ssh_keep_alive_interval" hcl:"ssh_keep_alive_interval"`
+	SSHReadWriteTimeout  *string `mapstructure:"ssh_read_write_timeout" cty:"ssh_read_write_timeout" hcl:"ssh_read_write_timeout"`
+	Communicator         *string `mapstructure:"communicator" cty:"communicator" hcl:"communicator"`
+	WinRMUser            *string `mapstructure:"winrm_username" cty:"winrm_username" hcl:"winrm_username"`
+	WinRMPassword        *string `mapstructure:"winrm_password" cty:"winrm_password" hcl:"winrm_password"`
+	WinRMTimeout         *string `mapstructure:"winrm_timeout" cty:"winrm_timeout" hcl:"winrm_timeout"`
 
 	CleanTraffic         *bool   `mapstructure:"clean_traffic" cty:"clean_traffic" hcl:"clean_traffic"`
 	ImageReadyTimeoutRaw *string `mapstructure:"image_ready_timeout" cty:"image_ready_timeout" hcl:"image_ready_timeout"`
@@ -99,27 +102,27 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"userdata":               &hcldec.AttrSpec{Name: "userdata", Type: cty.String, Required: false},
 		"memory_size":            &hcldec.AttrSpec{Name: "memory_size", Type: cty.Number, Required: false},
 		"cpu_num":                &hcldec.AttrSpec{Name: "cpu_num", Type: cty.Number, Required: false},
-		"backup_storage_name": &hcldec.AttrSpec{Name: "backup_storage_name", Type: cty.String, Required: false},
-		"backup_storage_uuid": &hcldec.AttrSpec{Name: "backup_storage_uuid", Type: cty.String, Required: false},
+		"backup_storage_name":    &hcldec.AttrSpec{Name: "backup_storage_name", Type: cty.String, Required: false},
+		"backup_storage_uuid":    &hcldec.AttrSpec{Name: "backup_storage_uuid", Type: cty.String, Required: false},
 
-		"ssh_host":               &hcldec.AttrSpec{Name: "ssh_host", Type: cty.String, Required: false},
-		"ssh_port":               &hcldec.AttrSpec{Name: "ssh_port", Type: cty.Number, Required: false},
-		"ssh_username":           &hcldec.AttrSpec{Name: "ssh_username", Type: cty.String, Required: false},
-		"ssh_password":           &hcldec.AttrSpec{Name: "ssh_password", Type: cty.String, Required: false},
-		"ssh_timeout":            &hcldec.AttrSpec{Name: "ssh_timeout", Type: cty.String, Required: false},
-		"ssh_handshake_attempts": &hcldec.AttrSpec{Name: "ssh_handshake_attempts", Type: cty.Number, Required: false},
-		"ssh_private_key_file":   &hcldec.AttrSpec{Name: "ssh_private_key_file", Type: cty.String, Required: false},
-		"ssh_agent_auth":         &hcldec.AttrSpec{Name: "ssh_agent_auth", Type: cty.Bool, Required: false},
+		"ssh_host":                &hcldec.AttrSpec{Name: "ssh_host", Type: cty.String, Required: false},
+		"ssh_port":                &hcldec.AttrSpec{Name: "ssh_port", Type: cty.Number, Required: false},
+		"ssh_username":            &hcldec.AttrSpec{Name: "ssh_username", Type: cty.String, Required: false},
+		"ssh_password":            &hcldec.AttrSpec{Name: "ssh_password", Type: cty.String, Required: false},
+		"ssh_timeout":             &hcldec.AttrSpec{Name: "ssh_timeout", Type: cty.String, Required: false},
+		"ssh_handshake_attempts":  &hcldec.AttrSpec{Name: "ssh_handshake_attempts", Type: cty.Number, Required: false},
+		"ssh_private_key_file":    &hcldec.AttrSpec{Name: "ssh_private_key_file", Type: cty.String, Required: false},
+		"ssh_agent_auth":          &hcldec.AttrSpec{Name: "ssh_agent_auth", Type: cty.Bool, Required: false},
 		"ssh_keep_alive_interval": &hcldec.AttrSpec{Name: "ssh_keep_alive_interval", Type: cty.String, Required: false},
 		"ssh_read_write_timeout":  &hcldec.AttrSpec{Name: "ssh_read_write_timeout", Type: cty.String, Required: false},
-		"communicator":           &hcldec.AttrSpec{Name: "communicator", Type: cty.String, Required: false},
-		"winrm_username":         &hcldec.AttrSpec{Name: "winrm_username", Type: cty.String, Required: false},
-		"winrm_password":         &hcldec.AttrSpec{Name: "winrm_password", Type: cty.String, Required: false},
-		"winrm_timeout":          &hcldec.AttrSpec{Name: "winrm_timeout", Type: cty.String, Required: false},
+		"communicator":            &hcldec.AttrSpec{Name: "communicator", Type: cty.String, Required: false},
+		"winrm_username":          &hcldec.AttrSpec{Name: "winrm_username", Type: cty.String, Required: false},
+		"winrm_password":          &hcldec.AttrSpec{Name: "winrm_password", Type: cty.String, Required: false},
+		"winrm_timeout":           &hcldec.AttrSpec{Name: "winrm_timeout", Type: cty.String, Required: false},
 
-		"clean_traffic":        &hcldec.AttrSpec{Name: "clean_traffic", Type: cty.Bool, Required: false},
-		"image_ready_timeout":  &hcldec.AttrSpec{Name: "image_ready_timeout", Type: cty.String, Required: false},
-		"vm_running_timeout":   &hcldec.AttrSpec{Name: "vm_running_timeout", Type: cty.String, Required: false},
+		"clean_traffic":       &hcldec.AttrSpec{Name: "clean_traffic", Type: cty.Bool, Required: false},
+		"image_ready_timeout": &hcldec.AttrSpec{Name: "image_ready_timeout", Type: cty.String, Required: false},
+		"vm_running_timeout":  &hcldec.AttrSpec{Name: "vm_running_timeout", Type: cty.String, Required: false},
 	}
 
 	return s

--- a/builder/zstack/builder_test.go
+++ b/builder/zstack/builder_test.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (
@@ -37,7 +40,8 @@ func TestBuilderPrepare_UsesAccessConfigEnvVars(t *testing.T) {
 
 	var b Builder
 	_, _, err := b.Prepare(map[string]interface{}{
-		"communicator": "none",
+		"communicator":        "none",
+		"backup_storage_name": "local-backup",
 	})
 
 	assert.NoError(t, err)
@@ -96,6 +100,7 @@ func TestBuilderPrepare_ValidTimeouts(t *testing.T) {
 		"zstack_host":         "example.com",
 		"account_name":        "admin",
 		"account_password":    "pw",
+		"backup_storage_name": "local-backup",
 		"image_ready_timeout": "10m",
 		"vm_running_timeout":  "2m",
 	})

--- a/builder/zstack/config.go
+++ b/builder/zstack/config.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (
@@ -31,9 +34,9 @@ type Config struct {
 	BackupStorageConfig `mapstructure:",squash"`
 	ExportImageResult   `mapstructure:",squash"`
 
-	CleanTraffic           bool   `mapstructure:"clean_traffic"`
-	ImageReadyTimeoutRaw   string `mapstructure:"image_ready_timeout"`
-	VmRunningTimeoutRaw    string `mapstructure:"vm_running_timeout"`
+	CleanTraffic         bool   `mapstructure:"clean_traffic"`
+	ImageReadyTimeoutRaw string `mapstructure:"image_ready_timeout"`
+	VmRunningTimeoutRaw  string `mapstructure:"vm_running_timeout"`
 
 	imageReadyTimeout time.Duration
 	vmRunningTimeout  time.Duration
@@ -170,13 +173,14 @@ func (c *Config) Prepare(raws ...any) error {
 		}
 	}
 
+	if c.BackupStorageConfig.BackupStorageUuid == "" && c.BackupStorageConfig.BackupStorageName == "" {
+		errs = packersdk.MultiErrorAppend(errs, errors.New("backup_storage_name or backup_storage_uuid is required"))
+	}
+
 	if c.SourceVolumeSnapshotUuid != "" {
 		log.Printf("[INFO] Configuring image creation from volume snapshot: %s", c.SourceVolumeSnapshotUuid)
 		if c.ImageName == "" {
 			errs = packersdk.MultiErrorAppend(errs, errors.New("image_name must be specified when using source_volume_snapshot_uuid"))
-		}
-		if c.BackupStorageConfig.BackupStorageUuid == "" && c.BackupStorageConfig.BackupStorageName == "" {
-			errs = packersdk.MultiErrorAppend(errs, errors.New("backup_storage_name or backup_storage_uuid is required when using source_volume_snapshot_uuid"))
 		}
 		if c.Platform == "" {
 			c.Platform = "Linux"

--- a/builder/zstack/driver.go
+++ b/builder/zstack/driver.go
@@ -1,11 +1,11 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (
-	"context"
 	"fmt"
 	"log"
-	"net"
-	"time"
 
 	"github.com/zstackio/zstack-sdk-go-v2/pkg/client"
 	"github.com/zstackio/zstack-sdk-go-v2/pkg/param"
@@ -34,6 +34,7 @@ type Driver interface {
 	DestroyVmInstance(uuid string) error
 	DeleteVmInstance(uuid string) error
 
+	CreateVolumeSnapshot(volumeUuid string, params param.CreateVolumeSnapshotParam) (*view.VolumeSnapshotInventoryView, error)
 	CreateImage(rootVolumeUuid string, params param.CreateRootVolumeTemplateFromRootVolumeParam) (*view.ImageInventoryView, error)
 	CreateImageFromVolumeSnapshot(snapshotUuid string, params param.CreateRootVolumeTemplateFromVolumeSnapshotParam) (*view.ImageInventoryView, error)
 	GetVolumeSnapshot(uuid string) (*view.VolumeSnapshotInventoryView, error)
@@ -204,6 +205,16 @@ func (d *ZStackDriver) DestroyVmInstance(uuid string) error {
 	return nil
 }
 
+func (d *ZStackDriver) CreateVolumeSnapshot(volumeUuid string, snapshotParam param.CreateVolumeSnapshotParam) (*view.VolumeSnapshotInventoryView, error) {
+	log.Printf("[INFO] Creating volume snapshot from volume '%s'", volumeUuid)
+	snapshot, err := d.client.CreateVolumeSnapshot(volumeUuid, snapshotParam)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create volume snapshot from volume '%s': %v", volumeUuid, err)
+	}
+	log.Printf("[INFO] Successfully created volume snapshot '%s' from volume '%s'", snapshot.UUID, volumeUuid)
+	return snapshot, nil
+}
+
 func (d *ZStackDriver) CreateImage(rootVolumeUuid string, rootVolumeParam param.CreateRootVolumeTemplateFromRootVolumeParam) (*view.ImageInventoryView, error) {
 	log.Printf("[INFO] Creating image from root volume.")
 	img, err := d.client.CreateRootVolumeTemplateFromRootVolume(rootVolumeUuid, rootVolumeParam)
@@ -305,42 +316,4 @@ func (d *ZStackDriver) AttachDataVolumeToVm(vmUuid, volumeUuid string) (*view.Vo
 	}
 	log.Printf("[INFO] Successfully attached data volume '%s' to VM '%s'", volumeUuid, vmUuid)
 	return datavol, nil
-}
-
-func (d *ZStackDriver) WaitForSSH(vmUuid string, sshPort int, timeout time.Duration) error {
-	log.Printf("[INFO] Waiting for SSH connectivity on VM %s", vmUuid)
-	vm, err := d.GetVmInstance(vmUuid)
-	if err != nil {
-		return fmt.Errorf("failed to get VM instance: %v", err)
-	}
-
-	if len(vm.VmNics) == 0 || vm.VmNics[0].Ip == "" {
-		return fmt.Errorf("VM '%s' has no default IP to connect", vmUuid)
-	}
-	ip := vm.VmNics[0].Ip
-
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	ticker := time.NewTicker(5 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("timeout waiting for SSH on VM '%s'", vmUuid)
-		case <-ticker.C:
-			conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", ip, sshPort), 5*time.Second)
-			if err == nil {
-				conn.Close()
-				log.Printf("[INFO] Successfully established SSH connection to %s:%d", ip, sshPort)
-				return nil
-			}
-			log.Printf("[DEBUG] SSH connection attempt to %s:%d failed, retrying...", ip, sshPort)
-		}
-	}
-}
-
-func addSystemTags(tags []string, args ...string) []string {
-	return append(tags, args...)
 }

--- a/builder/zstack/misc_helpers_test.go
+++ b/builder/zstack/misc_helpers_test.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (

--- a/builder/zstack/mock_driver_test.go
+++ b/builder/zstack/mock_driver_test.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (
@@ -86,6 +89,12 @@ type MockDriver struct {
 	CreateImageCalled         bool
 	CreateImageRootVolumeUuid string
 	CreateImageParam          param.CreateRootVolumeTemplateFromRootVolumeParam
+
+	CreateVolumeSnapshotResult     *view.VolumeSnapshotInventoryView
+	CreateVolumeSnapshotErr        error
+	CreateVolumeSnapshotCalled     bool
+	CreateVolumeSnapshotVolumeUuid string
+	CreateVolumeSnapshotParam      param.CreateVolumeSnapshotParam
 
 	CreateImageFromSnapshotResult       *view.ImageInventoryView
 	CreateImageFromSnapshotErr          error
@@ -215,6 +224,12 @@ func (m *MockDriver) CreateImage(rootVolumeUuid string, params param.CreateRootV
 	m.CreateImageRootVolumeUuid = rootVolumeUuid
 	m.CreateImageParam = params
 	return m.CreateImageResult, m.CreateImageErr
+}
+func (m *MockDriver) CreateVolumeSnapshot(volumeUuid string, params param.CreateVolumeSnapshotParam) (*view.VolumeSnapshotInventoryView, error) {
+	m.CreateVolumeSnapshotCalled = true
+	m.CreateVolumeSnapshotVolumeUuid = volumeUuid
+	m.CreateVolumeSnapshotParam = params
+	return m.CreateVolumeSnapshotResult, m.CreateVolumeSnapshotErr
 }
 func (m *MockDriver) CreateImageFromVolumeSnapshot(snapshotUuid string, params param.CreateRootVolumeTemplateFromVolumeSnapshotParam) (*view.ImageInventoryView, error) {
 	m.CreateImageFromSnapshotCalled = true

--- a/builder/zstack/ssh_helper.go
+++ b/builder/zstack/ssh_helper.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (

--- a/builder/zstack/step_add_image.go
+++ b/builder/zstack/step_add_image.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (
@@ -19,8 +22,10 @@ func (s *StepAddImage) Run(ctx context.Context, state multistep.StateBag) multis
 	driver := state.Get("driver").(Driver)
 
 	if config.SourceImageUrl == "" || config.SourceImage == "" {
-		ui.Error("Source image URL or name is empty")
-		log.Printf("[ERROR] Source image URL or name is empty")
+		err := fmt.Errorf("source image URL or name is empty")
+		ui.Error(err.Error())
+		log.Printf("[ERROR] %v", err)
+		state.Put("error", err)
 		return multistep.ActionHalt
 	}
 
@@ -51,8 +56,10 @@ func (s *StepAddImage) Run(ctx context.Context, state multistep.StateBag) multis
 
 	img, err := driver.AddImage(imageParam)
 	if err != nil {
-		ui.Error(fmt.Sprintf("Failed to add image: %s", err))
-		log.Printf("[ERROR] Failed to add image: %v", err)
+		err = fmt.Errorf("failed to add image: %v", err)
+		ui.Error(err.Error())
+		log.Printf("[ERROR] %v", err)
+		state.Put("error", err)
 		return multistep.ActionHalt
 	}
 
@@ -60,7 +67,6 @@ func (s *StepAddImage) Run(ctx context.Context, state multistep.StateBag) multis
 	log.Printf("[INFO] Image added successfully with UUID: %s", img.UUID)
 
 	config.ImageUuid = img.UUID
-	state.Put("config", config)
 
 	return multistep.ActionContinue
 }

--- a/builder/zstack/step_add_image_test.go
+++ b/builder/zstack/step_add_image_test.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (

--- a/builder/zstack/step_attach_guesttools.go
+++ b/builder/zstack/step_attach_guesttools.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (

--- a/builder/zstack/step_attach_guesttools_test.go
+++ b/builder/zstack/step_attach_guesttools_test.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (

--- a/builder/zstack/step_create_image.go
+++ b/builder/zstack/step_create_image.go
@@ -1,9 +1,13 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
@@ -21,25 +25,105 @@ func (s *StepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 	ui.Say(fmt.Sprintf("Creating image '%s' from VM root volume...", config.ImageName))
 	log.Printf("[INFO] Starting image creation from root volume: %s", config.RootVolumeUuid)
 
+	if config.BackupStorageConfig.BackupStorageUuid == "" {
+		err := fmt.Errorf("backup storage UUID is empty, cannot create image from snapshot")
+		ui.Error(err.Error())
+		state.Put("error", err)
+		return multistep.ActionHalt
+	}
+
+	snapshotName := fmt.Sprintf("packer-%s-snapshot", config.ImageName)
+	snapshotDescription := "Auto created by packer-plugin-zstack before image creation"
+	createSnapshotParam := param.CreateVolumeSnapshotParam{
+		BaseParam: param.BaseParam{},
+		Params: param.CreateVolumeSnapshotParamDetail{
+			Name:        snapshotName,
+			Description: &snapshotDescription,
+		},
+	}
+
+	ui.Say(fmt.Sprintf("Creating snapshot from root volume '%s'...", config.RootVolumeUuid))
+	snapshot, err := driver.CreateVolumeSnapshot(config.RootVolumeUuid, createSnapshotParam)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Failed to create snapshot from root volume: %v", err))
+		log.Printf("[ERROR] Failed to create snapshot from root volume %s: %v", config.RootVolumeUuid, err)
+		state.Put("error", err)
+		return multistep.ActionHalt
+	}
+
+	ui.Say(fmt.Sprintf("Waiting for snapshot '%s' to become ready...", snapshot.UUID))
+	timeout := time.After(config.ImageReadyTimeout())
+	ticker := time.NewTicker(config.PollInterval())
+	defer ticker.Stop()
+
+	ready := false
+	for !ready {
+		select {
+		case <-timeout:
+			err := fmt.Errorf("timeout waiting for snapshot %s status to become ready", snapshot.UUID)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			log.Printf("[ERROR] %v", err)
+			return multistep.ActionHalt
+		case <-ticker.C:
+			current, getErr := driver.GetVolumeSnapshot(snapshot.UUID)
+			if getErr != nil {
+				ui.Error(getErr.Error())
+				log.Printf("[ERROR] Failed to get snapshot %s: %v", snapshot.UUID, getErr)
+				state.Put("error", getErr)
+				return multistep.ActionHalt
+			}
+			if current == nil {
+				err := fmt.Errorf("snapshot %s not found while waiting for ready status", snapshot.UUID)
+				ui.Error(err.Error())
+				log.Printf("[ERROR] %v", err)
+				state.Put("error", err)
+				return multistep.ActionHalt
+			}
+
+			log.Printf("[DEBUG] Snapshot %s status=%s state=%s", snapshot.UUID, current.Status, current.State)
+			if current.Status == "Ready" && current.State == "Enabled" {
+				ui.Say("Snapshot status is now ready!")
+				ready = true
+				continue
+			}
+			ui.Message(fmt.Sprintf("snapshot status is %s/%s, waiting...", current.Status, current.State))
+		case <-ctx.Done():
+			log.Printf("[INFO] Context cancelled while waiting for snapshot %s", snapshot.UUID)
+			return multistep.ActionHalt
+		}
+	}
+
+	log.Printf("[INFO] Successfully created volume snapshot with UUID: %s", snapshot.UUID)
+	ui.Say(fmt.Sprintf("Creating image '%s' from snapshot '%s'...", config.ImageName, snapshot.UUID))
+
 	description := config.ImageDescription
 	if description == "" {
 		description = "Auto created by packer-plugin-zstack"
 	}
 
-	createImageFromRootVolumeParam := param.CreateRootVolumeTemplateFromRootVolumeParam{
+	createImageFromSnapshotParam := param.CreateRootVolumeTemplateFromVolumeSnapshotParam{
 		BaseParam: param.BaseParam{},
-		Params: param.CreateRootVolumeTemplateFromRootVolumeParamDetail{
-			Name:        config.ImageName,
-			Description: &description,
+		Params: param.CreateRootVolumeTemplateFromVolumeSnapshotParamDetail{
+			Name:               config.ImageName,
+			Description:        &description,
+			BackupStorageUuids: []string{config.BackupStorageConfig.BackupStorageUuid},
 		},
 	}
-
-	// AC-003-03: Only include BackupStorageUuids when configured
-	if config.BackupStorageConfig.BackupStorageUuid != "" {
-		createImageFromRootVolumeParam.Params.BackupStorageUuids = []string{config.BackupStorageConfig.BackupStorageUuid}
+	if config.GuestOsType != "" {
+		gos := config.GuestOsType
+		createImageFromSnapshotParam.Params.GuestOsType = &gos
+	}
+	if config.Platform != "" {
+		platform := config.Platform
+		createImageFromSnapshotParam.Params.Platform = &platform
+	}
+	if config.Architecture != "" {
+		arch := config.Architecture
+		createImageFromSnapshotParam.Params.Architecture = &arch
 	}
 
-	image, err := driver.CreateImage(config.RootVolumeUuid, createImageFromRootVolumeParam)
+	image, err := driver.CreateImageFromVolumeSnapshot(snapshot.UUID, createImageFromSnapshotParam)
 	if err != nil {
 		ui.Error(fmt.Sprintf("Failed to create image: %v", err))
 		log.Printf("[ERROR] Failed to create image: %v", err)
@@ -48,7 +132,6 @@ func (s *StepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 	}
 
 	config.ImageUuid = image.UUID
-	state.Put("config", config)
 
 	log.Printf("[INFO] Successfully created image with UUID: %s", image.UUID)
 	ui.Say(fmt.Sprintf("Successfully created image '%s' (UUID: %s)", config.ImageName, image.UUID))

--- a/builder/zstack/step_create_image_from_snapshot.go
+++ b/builder/zstack/step_create_image_from_snapshot.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (
@@ -78,7 +81,6 @@ func (s *StepCreateImageFromSnapshot) Run(ctx context.Context, state multistep.S
 	}
 
 	config.ImageUuid = image.UUID
-	state.Put("config", config)
 
 	log.Printf("[INFO] Successfully created image with UUID: %s from snapshot %s", image.UUID, snapshotUuid)
 	ui.Say(fmt.Sprintf("Successfully created image '%s' (UUID: %s) from snapshot %s", config.ImageName, image.UUID, snapshotUuid))

--- a/builder/zstack/step_create_image_from_snapshot_test.go
+++ b/builder/zstack/step_create_image_from_snapshot_test.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (
@@ -151,6 +154,7 @@ func TestConfigPrepare_SnapshotMode(t *testing.T) {
 		err := c.Prepare()
 		if assert.Error(t, err) {
 			assert.Contains(t, err.Error(), "image_name")
+			assert.Contains(t, err.Error(), "backup_storage")
 		}
 	})
 
@@ -158,6 +162,19 @@ func TestConfigPrepare_SnapshotMode(t *testing.T) {
 		c := &Config{
 			AccessConfig: AccessConfig{Host: "h", AccountName: "a", AccountPassword: "p"},
 			ImageConfig:  ImageConfig{SourceVolumeSnapshotUuid: "snap-1", ImageName: "img"},
+		}
+		err := c.Prepare()
+		if assert.Error(t, err) {
+			assert.Contains(t, err.Error(), "backup_storage")
+		}
+	})
+
+	t.Run("MissingBackupStorageForVmBuild", func(t *testing.T) {
+		c := &Config{
+			AccessConfig:   AccessConfig{Host: "h", AccountName: "a", AccountPassword: "p"},
+			ImageConfig:    ImageConfig{ImageName: "img"},
+			NetworkConfig:  NetworkConfig{L3NetworkName: "net"},
+			InstanceConfig: InstanceConfig{InstanceName: "vm", InstanceOfferingName: "small"},
 		}
 		err := c.Prepare()
 		if assert.Error(t, err) {

--- a/builder/zstack/step_create_image_test.go
+++ b/builder/zstack/step_create_image_test.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (
@@ -7,39 +10,98 @@ import (
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	"github.com/stretchr/testify/assert"
-	"github.com/zstackio/zstack-sdk-go-v2/pkg/param"
 	"github.com/zstackio/zstack-sdk-go-v2/pkg/view"
 )
 
-type createImageCaptureDriver struct {
-	*MockDriver
-	RootVolumeUuid string
-	Params         param.CreateRootVolumeTemplateFromRootVolumeParam
-}
-
-func (d *createImageCaptureDriver) CreateImage(rootVolumeUuid string, params param.CreateRootVolumeTemplateFromRootVolumeParam) (*view.ImageInventoryView, error) {
-	d.CreateImageCalled = true
-	d.RootVolumeUuid = rootVolumeUuid
-	d.Params = params
-	return d.CreateImageResult, d.CreateImageErr
-}
-
 func TestStepCreateImage_Run(t *testing.T) {
+	t.Run("CreateSnapshotThenImageSuccess", func(t *testing.T) {
+		config := &Config{
+			ImageConfig:         ImageConfig{ImageName: "img-name"},
+			InstanceConfig:      InstanceConfig{RootVolumeUuid: "root-vol-1"},
+			BackupStorageConfig: BackupStorageConfig{BackupStorageUuid: "bs-1"},
+		}
+		driver := &MockDriver{
+			CreateVolumeSnapshotResult:    &view.VolumeSnapshotInventoryView{BaseInfoView: view.BaseInfoView{UUID: "snap-uuid-1"}, Status: "Ready", State: "Enabled"},
+			CreateImageFromSnapshotResult: &view.ImageInventoryView{BaseInfoView: view.BaseInfoView{UUID: "img-uuid-1"}},
+			GetVolumeSnapshotResult:       &view.VolumeSnapshotInventoryView{BaseInfoView: view.BaseInfoView{UUID: "snap-uuid-1"}, Status: "Ready", State: "Enabled"},
+		}
+		state := testStateBag(config, driver)
+
+		action := (&StepCreateImage{}).Run(context.Background(), state)
+
+		assert.Equal(t, multistep.ActionContinue, action)
+		assert.True(t, driver.CreateVolumeSnapshotCalled)
+		assert.Equal(t, "root-vol-1", driver.CreateVolumeSnapshotVolumeUuid)
+		if assert.NotNil(t, driver.CreateVolumeSnapshotParam.Params.Description) {
+			assert.Equal(t, "Auto created by packer-plugin-zstack before image creation", *driver.CreateVolumeSnapshotParam.Params.Description)
+		}
+		assert.True(t, driver.CreateImageFromSnapshotCalled)
+		assert.Equal(t, "snap-uuid-1", driver.CreateImageFromSnapshotSnapshotUuid)
+		assert.Equal(t, []string{"bs-1"}, driver.CreateImageFromSnapshotParam.Params.BackupStorageUuids)
+		assert.Equal(t, "img-uuid-1", config.ImageUuid)
+	})
+
+	t.Run("CreateSnapshotError", func(t *testing.T) {
+		expectedErr := errors.New("create snapshot failed")
+		config := &Config{
+			ImageConfig:         ImageConfig{ImageName: "img-name"},
+			InstanceConfig:      InstanceConfig{RootVolumeUuid: "root-vol-1"},
+			BackupStorageConfig: BackupStorageConfig{BackupStorageUuid: "bs-1"},
+		}
+		driver := &MockDriver{CreateVolumeSnapshotErr: expectedErr}
+		state := testStateBag(config, driver)
+
+		action := (&StepCreateImage{}).Run(context.Background(), state)
+
+		assert.Equal(t, multistep.ActionHalt, action)
+		errVal, ok := state.GetOk("error")
+		assert.True(t, ok)
+		assert.Equal(t, expectedErr, errVal)
+		assert.False(t, driver.CreateImageFromSnapshotCalled)
+	})
+
+	t.Run("WaitSnapshotReadyError", func(t *testing.T) {
+		expectedErr := errors.New("get snapshot failed")
+		config := &Config{
+			ImageConfig:         ImageConfig{ImageName: "img-name"},
+			InstanceConfig:      InstanceConfig{RootVolumeUuid: "root-vol-1"},
+			BackupStorageConfig: BackupStorageConfig{BackupStorageUuid: "bs-1"},
+		}
+		driver := &MockDriver{
+			CreateVolumeSnapshotResult: &view.VolumeSnapshotInventoryView{BaseInfoView: view.BaseInfoView{UUID: "snap-uuid-1"}},
+			GetVolumeSnapshotErr:       expectedErr,
+		}
+		state := testStateBag(config, driver)
+
+		action := (&StepCreateImage{}).Run(context.Background(), state)
+
+		assert.Equal(t, multistep.ActionHalt, action)
+		errVal, ok := state.GetOk("error")
+		assert.True(t, ok)
+		assert.Equal(t, expectedErr, errVal)
+		assert.False(t, driver.CreateImageFromSnapshotCalled)
+	})
+
 	t.Run("CreateImageSuccess", func(t *testing.T) {
 		config := &Config{
 			ImageConfig:         ImageConfig{ImageName: "img-name"},
 			InstanceConfig:      InstanceConfig{RootVolumeUuid: "root-vol-1"},
 			BackupStorageConfig: BackupStorageConfig{BackupStorageUuid: "bs-1"},
 		}
-		driver := &createImageCaptureDriver{MockDriver: &MockDriver{CreateImageResult: &view.ImageInventoryView{BaseInfoView: view.BaseInfoView{UUID: "img-uuid-1"}}}}
+		driver := &MockDriver{
+			CreateVolumeSnapshotResult:    &view.VolumeSnapshotInventoryView{BaseInfoView: view.BaseInfoView{UUID: "snap-uuid-1"}, Status: "Ready", State: "Enabled"},
+			CreateImageFromSnapshotResult: &view.ImageInventoryView{BaseInfoView: view.BaseInfoView{UUID: "img-uuid-1"}},
+			GetVolumeSnapshotResult:       &view.VolumeSnapshotInventoryView{BaseInfoView: view.BaseInfoView{UUID: "snap-uuid-1"}, Status: "Ready", State: "Enabled"},
+		}
 		state := testStateBag(config, driver)
 
 		action := (&StepCreateImage{}).Run(context.Background(), state)
 
 		assert.Equal(t, multistep.ActionContinue, action)
-		assert.True(t, driver.CreateImageCalled)
+		assert.True(t, driver.CreateVolumeSnapshotCalled)
+		assert.True(t, driver.CreateImageFromSnapshotCalled)
 		assert.Equal(t, "img-uuid-1", config.ImageUuid)
-		assert.Equal(t, "root-vol-1", driver.RootVolumeUuid)
+		assert.Equal(t, "root-vol-1", driver.CreateVolumeSnapshotVolumeUuid)
 	})
 
 	t.Run("CreateImageNoBackupStorage", func(t *testing.T) {
@@ -47,55 +109,73 @@ func TestStepCreateImage_Run(t *testing.T) {
 			ImageConfig:    ImageConfig{ImageName: "img-name"},
 			InstanceConfig: InstanceConfig{RootVolumeUuid: "root-vol-1"},
 		}
-		driver := &createImageCaptureDriver{MockDriver: &MockDriver{CreateImageResult: &view.ImageInventoryView{BaseInfoView: view.BaseInfoView{UUID: "img-uuid-1"}}}}
+		driver := &MockDriver{}
 		state := testStateBag(config, driver)
 
 		action := (&StepCreateImage{}).Run(context.Background(), state)
 
-		assert.Equal(t, multistep.ActionContinue, action)
-		assert.True(t, driver.CreateImageCalled)
-		assert.Nil(t, driver.Params.Params.BackupStorageUuids)
+		assert.Equal(t, multistep.ActionHalt, action)
+		errVal, ok := state.GetOk("error")
+		assert.True(t, ok)
+		assert.Contains(t, errVal.(error).Error(), "backup storage UUID")
+		assert.False(t, driver.CreateVolumeSnapshotCalled)
+		assert.False(t, driver.CreateImageFromSnapshotCalled)
 	})
 
 	t.Run("CreateImageWithDescription", func(t *testing.T) {
 		config := &Config{
-			ImageConfig:    ImageConfig{ImageName: "img-name", ImageDescription: "custom desc"},
-			InstanceConfig: InstanceConfig{RootVolumeUuid: "root-vol-1"},
+			ImageConfig:         ImageConfig{ImageName: "img-name", ImageDescription: "custom desc"},
+			InstanceConfig:      InstanceConfig{RootVolumeUuid: "root-vol-1"},
+			BackupStorageConfig: BackupStorageConfig{BackupStorageUuid: "bs-1"},
 		}
-		driver := &createImageCaptureDriver{MockDriver: &MockDriver{CreateImageResult: &view.ImageInventoryView{BaseInfoView: view.BaseInfoView{UUID: "img-uuid-1"}}}}
+		driver := &MockDriver{
+			CreateVolumeSnapshotResult:    &view.VolumeSnapshotInventoryView{BaseInfoView: view.BaseInfoView{UUID: "snap-uuid-1"}, Status: "Ready", State: "Enabled"},
+			CreateImageFromSnapshotResult: &view.ImageInventoryView{BaseInfoView: view.BaseInfoView{UUID: "img-uuid-1"}},
+			GetVolumeSnapshotResult:       &view.VolumeSnapshotInventoryView{BaseInfoView: view.BaseInfoView{UUID: "snap-uuid-1"}, Status: "Ready", State: "Enabled"},
+		}
 		state := testStateBag(config, driver)
 
 		action := (&StepCreateImage{}).Run(context.Background(), state)
 
 		assert.Equal(t, multistep.ActionContinue, action)
-		if assert.NotNil(t, driver.Params.Params.Description) {
-			assert.Equal(t, "custom desc", *driver.Params.Params.Description)
+		if assert.NotNil(t, driver.CreateImageFromSnapshotParam.Params.Description) {
+			assert.Equal(t, "custom desc", *driver.CreateImageFromSnapshotParam.Params.Description)
 		}
 	})
 
 	t.Run("CreateImageDefaultDescription", func(t *testing.T) {
 		config := &Config{
-			ImageConfig:    ImageConfig{ImageName: "img-name"},
-			InstanceConfig: InstanceConfig{RootVolumeUuid: "root-vol-1"},
+			ImageConfig:         ImageConfig{ImageName: "img-name"},
+			InstanceConfig:      InstanceConfig{RootVolumeUuid: "root-vol-1"},
+			BackupStorageConfig: BackupStorageConfig{BackupStorageUuid: "bs-1"},
 		}
-		driver := &createImageCaptureDriver{MockDriver: &MockDriver{CreateImageResult: &view.ImageInventoryView{BaseInfoView: view.BaseInfoView{UUID: "img-uuid-1"}}}}
+		driver := &MockDriver{
+			CreateVolumeSnapshotResult:    &view.VolumeSnapshotInventoryView{BaseInfoView: view.BaseInfoView{UUID: "snap-uuid-1"}, Status: "Ready", State: "Enabled"},
+			CreateImageFromSnapshotResult: &view.ImageInventoryView{BaseInfoView: view.BaseInfoView{UUID: "img-uuid-1"}},
+			GetVolumeSnapshotResult:       &view.VolumeSnapshotInventoryView{BaseInfoView: view.BaseInfoView{UUID: "snap-uuid-1"}, Status: "Ready", State: "Enabled"},
+		}
 		state := testStateBag(config, driver)
 
 		action := (&StepCreateImage{}).Run(context.Background(), state)
 
 		assert.Equal(t, multistep.ActionContinue, action)
-		if assert.NotNil(t, driver.Params.Params.Description) {
-			assert.Equal(t, "Auto created by packer-plugin-zstack", *driver.Params.Params.Description)
+		if assert.NotNil(t, driver.CreateImageFromSnapshotParam.Params.Description) {
+			assert.Equal(t, "Auto created by packer-plugin-zstack", *driver.CreateImageFromSnapshotParam.Params.Description)
 		}
 	})
 
 	t.Run("CreateImageError", func(t *testing.T) {
 		expectedErr := errors.New("create image failed")
 		config := &Config{
-			ImageConfig:    ImageConfig{ImageName: "img-name"},
-			InstanceConfig: InstanceConfig{RootVolumeUuid: "root-vol-1"},
+			ImageConfig:         ImageConfig{ImageName: "img-name"},
+			InstanceConfig:      InstanceConfig{RootVolumeUuid: "root-vol-1"},
+			BackupStorageConfig: BackupStorageConfig{BackupStorageUuid: "bs-1"},
 		}
-		driver := &createImageCaptureDriver{MockDriver: &MockDriver{CreateImageErr: expectedErr}}
+		driver := &MockDriver{
+			CreateVolumeSnapshotResult: &view.VolumeSnapshotInventoryView{BaseInfoView: view.BaseInfoView{UUID: "snap-uuid-1"}, Status: "Ready", State: "Enabled"},
+			CreateImageFromSnapshotErr: expectedErr,
+			GetVolumeSnapshotResult:    &view.VolumeSnapshotInventoryView{BaseInfoView: view.BaseInfoView{UUID: "snap-uuid-1"}, Status: "Ready", State: "Enabled"},
+		}
 		state := testStateBag(config, driver)
 
 		action := (&StepCreateImage{}).Run(context.Background(), state)

--- a/builder/zstack/step_create_sshkey.go
+++ b/builder/zstack/step_create_sshkey.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (
@@ -38,7 +41,6 @@ func (s *StepCreateSSHKey) Run(ctx context.Context, state multistep.StateBag) mu
 			return multistep.ActionHalt
 		}
 		config.Comm.SSHPrivateKey = privateKeyBytes
-		state.Put("config", config)
 		return multistep.ActionContinue
 	}
 
@@ -47,7 +49,7 @@ func (s *StepCreateSSHKey) Run(ctx context.Context, state multistep.StateBag) mu
 	if err != nil {
 		err := fmt.Errorf("error creating temporary ssh key: %s", err)
 		state.Put("error", err)
-		ui.Errorf(err.Error())
+		ui.Error(err.Error())
 		return multistep.ActionHalt
 	}
 
@@ -61,7 +63,7 @@ func (s *StepCreateSSHKey) Run(ctx context.Context, state multistep.StateBag) mu
 	if err != nil {
 		err := fmt.Errorf("error creating temporary ssh key: %s", err)
 		state.Put("error", err)
-		ui.Errorf(err.Error())
+		ui.Error(err.Error())
 		return multistep.ActionHalt
 	}
 
@@ -72,7 +74,6 @@ func (s *StepCreateSSHKey) Run(ctx context.Context, state multistep.StateBag) mu
 		config.Comm.SSHPublicKey = config.Comm.SSHPublicKey[:len(config.Comm.SSHPublicKey)-1]
 	}
 	config.SshKey = string(config.Comm.SSHPublicKey)
-	state.Put("config", config)
 
 	if s.Debug {
 		ui.Message(fmt.Sprintf("Saving key for debug purposes: %s", s.DebugKeyPath))

--- a/builder/zstack/step_create_sshkey_test.go
+++ b/builder/zstack/step_create_sshkey_test.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (

--- a/builder/zstack/step_create_vminstance.go
+++ b/builder/zstack/step_create_vminstance.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (
@@ -79,7 +82,6 @@ func (s *StepCreateVMInstance) Run(ctx context.Context, state multistep.StateBag
 	}
 	config.IP = instance.VmNics[0].Ip
 
-	state.Put("config", config)
 	log.Printf("[INFO] Successfully created VM instance (UUID: %s, IP: %s)", instance.UUID, config.IP)
 	ui.Say(fmt.Sprintf("Successfully created VM instance '%s' (UUID: %s, IP: %s)",
 		config.InstanceName, instance.UUID, config.IP))

--- a/builder/zstack/step_create_vminstance_test.go
+++ b/builder/zstack/step_create_vminstance_test.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (

--- a/builder/zstack/step_delete_vminstance.go
+++ b/builder/zstack/step_delete_vminstance.go
@@ -1,7 +1,11 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (
 	"context"
+	"log"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
@@ -23,16 +27,18 @@ func (s *StepExpungeVmInstance) Run(ctx context.Context, state multistep.StateBa
 
 	ui.Say("Expunging VM instance...")
 
+	// Image is already created at this point; treat cleanup failures as
+	// non-fatal warnings so the build still surfaces a usable artifact.
 	if err := driver.DestroyVmInstance(instanceUuid); err != nil {
-		ui.Error("Failed to destroy VM instance: " + err.Error())
-		state.Put("error", err)
-		return multistep.ActionHalt
+		ui.Say("Warning: failed to destroy VM instance (non-fatal): " + err.Error())
+		log.Printf("[WARN] Failed to destroy VM instance %s during expunge: %v", instanceUuid, err)
+		return multistep.ActionContinue
 	}
 
 	if err := driver.DeleteVmInstance(instanceUuid); err != nil {
-		ui.Error("Failed to delete VM instance: " + err.Error())
-		state.Put("error", err)
-		return multistep.ActionHalt
+		ui.Say("Warning: failed to expunge VM instance (non-fatal): " + err.Error())
+		log.Printf("[WARN] Failed to expunge VM instance %s: %v", instanceUuid, err)
+		return multistep.ActionContinue
 	}
 
 	config.InstanceUuid = ""

--- a/builder/zstack/step_delete_vminstance_test.go
+++ b/builder/zstack/step_delete_vminstance_test.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (
@@ -37,32 +40,32 @@ func TestStepExpungeVmInstance_Run(t *testing.T) {
 		assert.Empty(t, config.InstanceUuid)
 	})
 
-	t.Run("DestroyErrorHalts", func(t *testing.T) {
+	t.Run("DestroyErrorWarnsAndContinues", func(t *testing.T) {
 		config := &Config{InstanceConfig: InstanceConfig{InstanceUuid: "vm-1"}}
 		driver := &MockDriver{DestroyVmInstanceErr: errors.New("destroy fail")}
 		state := testStateBag(config, driver)
 
 		action := (&StepExpungeVmInstance{}).Run(context.Background(), state)
 
-		assert.Equal(t, multistep.ActionHalt, action)
+		assert.Equal(t, multistep.ActionContinue, action)
 		assert.True(t, driver.DestroyVmInstanceCalled)
 		assert.False(t, driver.DeleteVmInstanceCalled)
 		_, ok := state.GetOk("error")
-		assert.True(t, ok)
+		assert.False(t, ok, "expunge cleanup failures must not poison build state")
 	})
 
-	t.Run("DeleteErrorHalts", func(t *testing.T) {
+	t.Run("DeleteErrorWarnsAndContinues", func(t *testing.T) {
 		config := &Config{InstanceConfig: InstanceConfig{InstanceUuid: "vm-1"}}
 		driver := &MockDriver{DeleteVmInstanceErr: errors.New("delete fail")}
 		state := testStateBag(config, driver)
 
 		action := (&StepExpungeVmInstance{}).Run(context.Background(), state)
 
-		assert.Equal(t, multistep.ActionHalt, action)
+		assert.Equal(t, multistep.ActionContinue, action)
 		assert.True(t, driver.DestroyVmInstanceCalled)
 		assert.True(t, driver.DeleteVmInstanceCalled)
 		_, ok := state.GetOk("error")
-		assert.True(t, ok)
+		assert.False(t, ok, "expunge cleanup failures must not poison build state")
 	})
 }
 

--- a/builder/zstack/step_export_image.go
+++ b/builder/zstack/step_export_image.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (
@@ -76,7 +79,6 @@ func (s *StepExportImage) Run(ctx context.Context, state multistep.StateBag) mul
 	}
 
 	config.ImageUrl = res.view.ImageUrl
-	state.Put("config", config)
 	ui.Say("Successfully exported image: " + config.ImageUrl)
 	return multistep.ActionContinue
 }

--- a/builder/zstack/step_export_image_test.go
+++ b/builder/zstack/step_export_image_test.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (

--- a/builder/zstack/step_instance_offering_validate.go
+++ b/builder/zstack/step_instance_offering_validate.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (
@@ -22,7 +25,6 @@ func (s *StepInstanceOfferingValidate) Run(ctx context.Context, state multistep.
 	if config.InstanceConfig.InstanceOfferingUuid != "" {
 		log.Printf("[INFO] Using provided instance offering UUID: %s", config.InstanceConfig.InstanceOfferingUuid)
 		ui.Say(fmt.Sprintf("Using provided instance offering UUID: %s", config.InstanceConfig.InstanceOfferingUuid))
-		state.Put("config", config)
 		return multistep.ActionContinue
 	}
 
@@ -34,7 +36,6 @@ func (s *StepInstanceOfferingValidate) Run(ctx context.Context, state multistep.
 
 	config.InstanceConfig.InstanceOfferingUuid = instanceOfferings[0].UUID
 	ui.Say("Instance offering validated")
-	state.Put("config", config)
 	return multistep.ActionContinue
 }
 

--- a/builder/zstack/step_instance_offering_validate_test.go
+++ b/builder/zstack/step_instance_offering_validate_test.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (

--- a/builder/zstack/step_pre_validate.go
+++ b/builder/zstack/step_pre_validate.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (
@@ -35,21 +38,13 @@ func (s *StepPreValidate) Run(ctx context.Context, state multistep.StateBag) mul
 		ui.Say("L3 network validated")
 	}
 
-	// source_image_url imports require backup storage for image download/import.
-	if config.SourceImageUrl != "" && config.BackupStorageConfig.BackupStorageUuid == "" && config.BackupStorageConfig.BackupStorageName == "" {
-		err := fmt.Errorf("backup_storage_name or backup_storage_uuid is required when source_image_url is set")
+	if config.BackupStorageConfig.BackupStorageUuid == "" && config.BackupStorageConfig.BackupStorageName == "" {
+		err := fmt.Errorf("backup_storage_name or backup_storage_uuid is required")
 		ui.Errorf("Backup storage validation failed: %s", err)
 		return multistep.ActionHalt
 	}
 
-	if snapshotOnly && config.BackupStorageConfig.BackupStorageUuid == "" && config.BackupStorageConfig.BackupStorageName == "" {
-		err := fmt.Errorf("backup_storage_name or backup_storage_uuid is required when source_volume_snapshot_uuid is set")
-		ui.Errorf("Backup storage validation failed: %s", err)
-		return multistep.ActionHalt
-	}
-
-	// AC-002-04: Skip backup storage query when backup_storage_uuid is provided
-	// AC-003-01: Backup storage is optional for non-import flows.
+	// AC-002-04: Skip backup storage query when backup_storage_uuid is provided.
 	if config.BackupStorageConfig.BackupStorageUuid != "" {
 		log.Printf("[INFO] Using provided backup storage UUID: %s", config.BackupStorageConfig.BackupStorageUuid)
 		ui.Say(fmt.Sprintf("Using provided backup storage UUID: %s", config.BackupStorageConfig.BackupStorageUuid))
@@ -61,12 +56,8 @@ func (s *StepPreValidate) Run(ctx context.Context, state multistep.StateBag) mul
 		}
 		config.BackupStorageConfig.BackupStorageUuid = backupStorages[0].UUID
 		ui.Say("Backup storage validated")
-	} else {
-		log.Printf("[INFO] No backup storage configured, image export will be skipped")
-		ui.Say("No backup storage configured, image export will be skipped")
 	}
 
-	state.Put("config", config)
 	return multistep.ActionContinue
 }
 

--- a/builder/zstack/step_pre_validate_test.go
+++ b/builder/zstack/step_pre_validate_test.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (
@@ -23,11 +26,13 @@ func TestStepPreValidate_Run(t *testing.T) {
 		{
 			name: "NetworkUuidPassthrough",
 			config: &Config{
-				NetworkConfig: NetworkConfig{L3NetworkUuid: "network-uuid"},
+				NetworkConfig:       NetworkConfig{L3NetworkUuid: "network-uuid"},
+				BackupStorageConfig: BackupStorageConfig{BackupStorageUuid: "backup-storage-uuid"},
 			},
-			driver:              &MockDriver{},
-			expectedAction:      multistep.ActionContinue,
-			expectedNetworkUUID: "network-uuid",
+			driver:                    &MockDriver{},
+			expectedAction:            multistep.ActionContinue,
+			expectedNetworkUUID:       "network-uuid",
+			expectedBackupStorageUUID: "backup-storage-uuid",
 			assertions: func(t *testing.T, driver *MockDriver) {
 				assert.False(t, driver.QueryL3NetworkCalled)
 			},
@@ -35,15 +40,17 @@ func TestStepPreValidate_Run(t *testing.T) {
 		{
 			name: "NetworkNameQuery",
 			config: &Config{
-				NetworkConfig: NetworkConfig{L3NetworkName: "network-name"},
+				NetworkConfig:       NetworkConfig{L3NetworkName: "network-name"},
+				BackupStorageConfig: BackupStorageConfig{BackupStorageUuid: "backup-storage-uuid"},
 			},
 			driver: &MockDriver{
 				QueryL3NetworkResult: []view.L3NetworkInventoryView{{
 					BaseInfoView: view.BaseInfoView{UUID: "network-uuid"},
 				}},
 			},
-			expectedAction:      multistep.ActionContinue,
-			expectedNetworkUUID: "network-uuid",
+			expectedAction:            multistep.ActionContinue,
+			expectedNetworkUUID:       "network-uuid",
+			expectedBackupStorageUUID: "backup-storage-uuid",
 			assertions: func(t *testing.T, driver *MockDriver) {
 				assert.True(t, driver.QueryL3NetworkCalled)
 				assert.Equal(t, "network-name", driver.QueryL3NetworkName)
@@ -108,11 +115,26 @@ func TestStepPreValidate_Run(t *testing.T) {
 		{
 			name: "BackupStorageOptionalSkip",
 			config: &Config{
-				NetworkConfig: NetworkConfig{L3NetworkUuid: "network-uuid"},
+				NetworkConfig:  NetworkConfig{L3NetworkUuid: "network-uuid"},
+				InstanceConfig: InstanceConfig{RootVolumeUuid: "root-volume-uuid"},
 			},
 			driver:              &MockDriver{},
-			expectedAction:      multistep.ActionContinue,
+			expectedAction:      multistep.ActionHalt,
 			expectedNetworkUUID: "network-uuid",
+			assertions: func(t *testing.T, driver *MockDriver) {
+				assert.False(t, driver.QueryBackStorageCalled)
+			},
+		},
+		{
+			name: "BackupStorageOptionalSkipWithoutRootVolume",
+			config: &Config{
+				NetworkConfig:       NetworkConfig{L3NetworkUuid: "network-uuid"},
+				BackupStorageConfig: BackupStorageConfig{BackupStorageUuid: "backup-storage-uuid"},
+			},
+			driver:                    &MockDriver{},
+			expectedAction:            multistep.ActionContinue,
+			expectedNetworkUUID:       "network-uuid",
+			expectedBackupStorageUUID: "backup-storage-uuid",
 			assertions: func(t *testing.T, driver *MockDriver) {
 				assert.False(t, driver.QueryBackStorageCalled)
 			},

--- a/builder/zstack/step_source_image_validate.go
+++ b/builder/zstack/step_source_image_validate.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (
@@ -22,7 +25,6 @@ func (s *StepSourceImageValidate) Run(ctx context.Context, state multistep.State
 	if config.ImageConfig.ImageUuid != "" {
 		log.Printf("[INFO] Using provided source image UUID: %s", config.ImageConfig.ImageUuid)
 		ui.Say(fmt.Sprintf("Using provided source image UUID: %s", config.ImageConfig.ImageUuid))
-		state.Put("config", config)
 		return multistep.ActionContinue
 	}
 
@@ -38,7 +40,6 @@ func (s *StepSourceImageValidate) Run(ctx context.Context, state multistep.State
 
 	config.ImageConfig.ImageUuid = images[0].UUID
 	ui.Say("Source image validated")
-	state.Put("config", config)
 	return multistep.ActionContinue
 }
 

--- a/builder/zstack/step_source_image_validate_test.go
+++ b/builder/zstack/step_source_image_validate_test.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (

--- a/builder/zstack/step_stop_vminstance.go
+++ b/builder/zstack/step_stop_vminstance.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (

--- a/builder/zstack/step_stop_vminstance_test.go
+++ b/builder/zstack/step_stop_vminstance_test.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (

--- a/builder/zstack/step_waitfor_image_ready.go
+++ b/builder/zstack/step_waitfor_image_ready.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (

--- a/builder/zstack/step_waitfor_image_ready_test.go
+++ b/builder/zstack/step_waitfor_image_ready_test.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (

--- a/builder/zstack/step_waitfor_instance_running.go
+++ b/builder/zstack/step_waitfor_instance_running.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (

--- a/builder/zstack/step_waitfor_instance_running_test.go
+++ b/builder/zstack/step_waitfor_instance_running_test.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package zstack
 
 import (

--- a/builder/zstack/test-fixtures/template.pkr.hcl
+++ b/builder/zstack/test-fixtures/template.pkr.hcl
@@ -1,4 +1,4 @@
-# Copyright (c) HashiCorp, Inc.
+# Copyright ZStack.io, Inc. 2013, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 source "scaffolding-my-builder" "basic-example" {

--- a/builder/zstack/utils/utils.go
+++ b/builder/zstack/utils/utils.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package utils
 
 func MBToBytes(mb int64) int64 {

--- a/builder/zstack/utils/utils_test.go
+++ b/builder/zstack/utils/utils_test.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package utils
 
 import "testing"

--- a/docs/builders/builder.mdx
+++ b/docs/builders/builder.mdx
@@ -21,7 +21,7 @@ The zstack builder is used to create ZStack Image by VM Instance
 
 - `access_key_id` (String) AccessKey ID for ZStack API. Create AccessKey ID from MN,  Operational Management->Access Control->AccessKey Management. May also be provided via ZSTACK_ACCESS_KEY_ID environment variable. Required if using AccessKey authentication. Mutually exclusive with `account_name` and `account_password`.
 - `access_key_secret` (String, Sensitive) AccessKey Secret for ZStack API. May also be provided via ZSTACK_ACCESS_KEY_SECRET environment variable. Required if using AccessKey authentication. Mutually exclusive with `account_name` and `account_password`.
-- `account_name` (String) Username for ZStack API. May also be provided via ZSTACK_ACCOUN_TNAME environment variable. Required if using Account authentication.  Only supports the platform administrator account (`admin`). Mutually exclusive with `access_key_id` and `access_key_secret`. Using `access_key_id` and `access_key_secret` is the recommended approach for authentication, as it provides more flexibility and security.
+- `account_name` (String) Username for ZStack API. May also be provided via ZSTACK_ACCOUNT_NAME environment variable. Required if using Account authentication.  Only supports the platform administrator account (`admin`). Mutually exclusive with `access_key_id` and `access_key_secret`. Using `access_key_id` and `access_key_secret` is the recommended approach for authentication, as it provides more flexibility and security.
 - `account_password` (String, Sensitive) Password for ZStack API. May also be provided via ZSTACK_ACCOUNT_PASSWORD environment variable.Required if using Account authentication.  Only supports the platform administrator account (`admin`). Mutually exclusive with `access_key_id` and `access_key_secret`. Using `access_key_id` and `access_key_secret` is the recommended approach for authentication, as it provides more flexibility and security.
 - `port` (Number) ZStack Cloud MN API port. May also be provided via ZSTACK_PORT environment variable.
 
@@ -46,7 +46,7 @@ The zstack builder is used to create ZStack Image by VM Instance
 
 - `image_description` (String) - Description for the created image. Defaults to the image name if not set.
 
-- `source_volume_snapshot_uuid` (String) - UUID of an existing ZStack volume snapshot. When set, the builder creates a root volume template directly from the snapshot and skips VM creation, SSH connection, and provisioners. Requires `image_name` and one of `backup_storage_name` / `backup_storage_uuid`.
+- `source_volume_snapshot_uuid` (String) - UUID of an existing ZStack volume snapshot. When set, the builder creates a root volume template from that existing snapshot and skips VM creation, SSH connection, and provisioners. Requires `image_name` and one of `backup_storage_name` / `backup_storage_uuid`.
 
 **Network Parameters**
 
@@ -69,7 +69,7 @@ The zstack builder is used to create ZStack Image by VM Instance
 **Storage Parameters**
 - `backup_storage_name` (String) - Name of the backup storage for storing created images.
 
-- `backup_storage_uuid` (String) - UUID of the backup storage. Optional - when neither backup_storage_name nor backup_storage_uuid is specified, the image export step is skipped.
+- `backup_storage_uuid` (String) - UUID of the backup storage. Required for image creation because the builder now produces the final image template through the snapshot-to-template flow.
 
 **SSH Parameters**
 - `ssh_username` (String) - SSH username for connecting to the created VM instance.
@@ -86,7 +86,7 @@ The zstack builder is used to create ZStack Image by VM Instance
 
 ```hcl
 source "zstack" "example" {
-  zstack_host       = "https://zstack.example.com"
+  zstack_host       = "zstack.example.com"
   access_key_id     = env("ZSTACK_ACCESS_KEY_ID")
   access_key_secret = env("ZSTACK_ACCESS_KEY_SECRET")
 
@@ -113,11 +113,11 @@ source "zstack" "example" {
 
 ### Example: Build From Volume Snapshot
 
-Skip VM creation entirely and build an image directly from an existing volume snapshot. No SSH connection or provisioners are required:
+Skip VM creation entirely and build an image from an existing volume snapshot. No SSH connection or provisioners are required:
 
 ```hcl
 source "zstack" "from_snapshot" {
-  zstack_host      = "https://zstack.example.com"
+  zstack_host      = "zstack.example.com"
   account_name     = env("ZSTACK_ACCOUNT_NAME")
   account_password = env("ZSTACK_ACCOUNT_PASSWORD")
 

--- a/example/aksk.pkr.hcl
+++ b/example/aksk.pkr.hcl
@@ -1,3 +1,6 @@
+# Copyright ZStack.io, Inc. 2013, 2026
+# SPDX-License-Identifier: MPL-2.0
+
 # AccessKey/Secret authentication with URL-based source image
 variable "zstack_host" {
   type    = string

--- a/example/basic.pkr.hcl
+++ b/example/basic.pkr.hcl
@@ -1,3 +1,6 @@
+# Copyright ZStack.io, Inc. 2013, 2026
+# SPDX-License-Identifier: MPL-2.0
+
 # Account/password authentication with source image name lookup
 variable "zstack_host" {
   type    = string

--- a/example/from_snapshot.pkr.hcl
+++ b/example/from_snapshot.pkr.hcl
@@ -1,4 +1,7 @@
-# Build an image directly from an existing ZStack volume snapshot (no VM/SSH/provisioning).
+# Copyright ZStack.io, Inc. 2013, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+# Build an image from an existing ZStack volume snapshot (no VM/SSH/provisioning).
 variable "zstack_host" {
   type    = string
   default = env("ZSTACK_HOST")

--- a/example/load_images.sh
+++ b/example/load_images.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+# Copyright ZStack.io, Inc. 2013, 2026
+# SPDX-License-Identifier: MPL-2.0
+
 set -eu
 
 echo "[load_images] start"

--- a/example/uuid.pkr.hcl
+++ b/example/uuid.pkr.hcl
@@ -1,3 +1,6 @@
+# Copyright ZStack.io, Inc. 2013, 2026
+# SPDX-License-Identifier: MPL-2.0
+
 # UUID passthrough - skip all name-based lookups
 variable "zstack_host" {
   type    = string
@@ -50,7 +53,9 @@ source "zstack" "uuid" {
   image_name        = "packer-uuid-image"
   image_description = "Built with Packer - UUID passthrough example"
 
-  # No backup_storage - export step will be skipped
+  backup_storage_name = "local-backup"
+
+  # Backup storage is required because the builder now creates the final image via snapshot -> image.
   ssh_username = "root"
   ssh_password = "your-ssh-password"
 }

--- a/main.go
+++ b/main.go
@@ -1,4 +1,5 @@
 // Copyright (c) HashiCorp, Inc.
+// Copyright ZStack.io, Inc. 2013, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package main

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,6 @@
+// Copyright ZStack.io, Inc. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package version
 
 import "github.com/hashicorp/packer-plugin-sdk/version"


### PR DESCRIPTION
QA fixes
- StepAddImage: propagate failure via state.Put("error") so collectArtifact surfaces it
- StepCreateSSHKey: use ui.Error instead of ui.Errorf(err.Error()) to avoid format injection
- access_config: thread PackerDebug into SDK client; bound Login() with a 30s timeout
- StepPreValidate: drop redundant backup-storage validation block
- StepExpungeVmInstance: warn-and-continue on cleanup failure (image is already created)
- driver: drop unused addSystemTags helper and unused WaitForSSH (StepConnect handles SSH)
- remove redundant state.Put("config", config) since config is *Config

Docs / examples
- fix zstack_host examples (SDK expects bare hostname, not URL with scheme)
- fix ZSTACK_ACCOUN_TNAME typo in builder.mdx
- sanitize stale .web-docs example that contained a real-looking AccessKey prefix
- add Chinese README (README_zh.md)

Repo hygiene
- ignore locally built plugin binaries under github.com/
- copywrite: set copyright_holder = "ZStack.io, Inc." and apply MPL-2.0 headers across the codebase; preserve original HashiCorp attribution on main.go and the web-docs compile script

go vet, go build, go test all pass; coverage 67.1% (utils 100%).